### PR TITLE
fix(tests): DB 依存テストをテスト専用 DB(ryza_test)へ恒久隔離 (Issue #23)

### DIFF
--- a/tests/bot/conftest.py
+++ b/tests/bot/conftest.py
@@ -1,30 +1,16 @@
 """bot テストの共通フィクスチャ。
 
-ライブ PostgreSQL(compose.yaml の DB)に対して実行する。接続できない場合は skip。
-各テストは関数スコープの接続を使い、commit せず rollback して隔離する。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。
+接続できない場合は skip。各テストは関数スコープの接続を使い、commit せず rollback して隔離する。
 discord API はモック(実際にはそもそも import しない — 純ロジックのみを検証する)。
 """
 
 from __future__ import annotations
 
-import psycopg
 import pytest
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.provenance import start_run
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    """DB に接続できれば全マイグレーションを適用して yield。不可なら skip。"""
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,90 @@
 """tests 全体の共有フィクスチャ。
 
-**残留データ隔離**(Issue #23): テストは compose.yaml のライブ PostgreSQL を
-日次取込ジョブ等と共有するため、commit 済みの実データ(market.indicators /
-market.bars / docs.documents など)が残っていると、テーブル全体を数える
-count assert が残留分を拾って壊れる。rollback 隔離はテスト自身の書込にしか
-効かない。
+**テスト専用 DB による恒久隔離**(Issue #23): DB 依存テストは以前、日次取込
+ジョブ等と同じ共有 PostgreSQL(compose.yaml の ``ryza``)に対して実行していた。
+rollback 隔離はテスト自身の書込にしか効かないため、別セッションが commit した
+実データ(docs.documents / market.indicators など)が残っていると、テーブル
+全体を数える count assert が壊れる(実例: 2026-08-03 の residual-seed Run)。
 
-対策として ``clear_residual`` フィクスチャを提供する: テストが開いた
-トランザクションの**内側で**対象テーブルを DELETE し、テスト終了時の
-rollback で削除ごと巻き戻す。commit しないため共有 DB の実データは無傷の
-まま、テストからは空のテーブルに見える。
+対策として ``pytest_configure`` で ``RYZA_DATABASE_URL`` を**テスト専用 DB**
+(既定: 元の dbname + ``_test`` → ``ryza_test``)へ差し替える。テスト DB は
+``migrated_db`` フィクスチャが初回に CREATE DATABASE し、全マイグレーションを
+適用する。取込ジョブはテスト DB に書かないため、残留データは原理的に発生
+しない。テスト DB を明示したい場合は ``RYZA_TEST_DATABASE_URL`` で上書きできる。
 
-TRUNCATE ではなく DELETE を使う理由: TRUNCATE は ACCESS EXCLUSIVE ロックを
-取り、並行して動く取込ジョブをブロックする。DELETE は ROW EXCLUSIVE で済む
-(削除行の行ロックは rollback まで保持されるが、テストは短命なので許容)。
+``clear_residual``(トランザクション内 DELETE、rollback で巻き戻し)は
+防御の第二層として残す: テストのバグで commit してしまった場合や、複数
+ワークツリーのテストセッションが同じテスト DB を並行使用した場合の保険。
 """
 
 from __future__ import annotations
 
+import os
+
+import psycopg
 import pytest
+from psycopg import conninfo, errors
+
+from ryza.db import migrate
+from ryza.db.conn import database_url
+
+# 差し替え前の(共有)DB URL。テスト DB の CREATE DATABASE 用の管理接続に使う。
+_ADMIN_URL: str = ""
+
+
+def _test_database_url(base_url: str) -> str:
+    """テスト専用 DB の URL。RYZA_TEST_DATABASE_URL があれば最優先。
+
+    既定は ``base_url`` の dbname に ``_test`` を付けたもの(``ryza`` → ``ryza_test``)。
+    既に ``_test`` で終わる場合はそのまま使う。
+    """
+    override = os.environ.get("RYZA_TEST_DATABASE_URL")
+    if override:
+        return override
+    params = conninfo.conninfo_to_dict(base_url)
+    dbname = params.get("dbname") or "ryza"
+    if not dbname.endswith("_test"):
+        dbname = f"{dbname}_test"
+    return conninfo.make_conninfo(base_url, dbname=dbname)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """収集より前に RYZA_DATABASE_URL をテスト専用 DB へ差し替える。
+
+    以後の ``ryza.db.conn.connect()`` / ``database_url()`` は全てテスト DB を
+    指すため、テストコード側の変更は不要。
+    """
+    global _ADMIN_URL
+    _ADMIN_URL = database_url()
+    os.environ["RYZA_DATABASE_URL"] = _test_database_url(_ADMIN_URL)
+
+
+@pytest.fixture(scope="session")
+def migrated_db():
+    """テスト専用 DB を(なければ)作成し、全マイグレーションを適用して yield。
+
+    PostgreSQL 自体に接続できない場合は skip(Docker 未導入環境向け)。
+    CREATE DATABASE はトランザクション外でしか実行できないため autocommit の
+    管理接続(元 URL)を使う。並行するテストセッションと作成が競合しても
+    DuplicateDatabase を握りつぶして続行する。
+    """
+    test_dbname = conninfo.conninfo_to_dict(database_url()).get("dbname")
+    try:
+        with psycopg.connect(_ADMIN_URL, autocommit=True, connect_timeout=3) as admin:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM pg_database WHERE datname = %s", (test_dbname,)
+                )
+                if cur.fetchone() is None:
+                    try:
+                        cur.execute(f'CREATE DATABASE "{test_dbname}"')
+                    except errors.DuplicateDatabase:
+                        pass
+    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
+        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
+    migrate.run()
+    yield
+
 
 # 取込・前処理テストが件数 assert の対象にするテーブル。FK の子 → 親の順。
 RESIDUAL_TABLES = (
@@ -50,7 +116,7 @@ def clear_residual():
     """接続を受け取り、そのトランザクション内で残留データを不可視にする関数。
 
     呼び出し側の ``conn`` フィクスチャが接続直後に呼ぶ。**commit してはならない**
-    (rollback で削除が巻き戻ることが共有 DB を守る前提)。
+    (rollback で削除が巻き戻ることがテスト DB を並行セッションと共有する前提)。
     """
 
     def _clear(conn) -> None:

--- a/tests/ingest/conftest.py
+++ b/tests/ingest/conftest.py
@@ -1,10 +1,9 @@
 """ingest テストの共通フィクスチャ。
 
-ライブ PostgreSQL（compose.yaml の DB）に対して実行する。接続できない場合は skip。
-各テストは関数スコープの接続を使い、commit せず rollback して隔離する。共有 DB に
-commit 済みの実データ(日次取込等)が残っていても件数 assert が壊れないよう、
-トランザクション内で対象テーブルを空にしてから yield する(tests/conftest.py の
-``clear_residual`` — rollback で削除ごと巻き戻るため実データは無傷)。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。
+接続できない場合は skip。各テストは関数スコープの接続を使い、commit せず rollback して
+隔離する。保険として、トランザクション内で対象テーブルを空にしてから yield する
+(tests/conftest.py の ``clear_residual`` — rollback で削除ごと巻き戻る)。
 
 **HTTP は全てモック**（受け入れ基準）。``FakeFetcher`` を注入し、取込コードは実 API へ
 一切アクセスしない。証憑ストアは ``tmp_path`` の ``LocalStorage``。
@@ -15,25 +14,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 
-import psycopg
 import pytest
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.ingest.base import FetchResult
 from ryza.provenance import EvidenceStore, LocalStorage, start_run
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    """DB に接続できれば全マイグレーションを適用して yield。不可なら skip。"""
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/jobs/conftest.py
+++ b/tests/jobs/conftest.py
@@ -1,7 +1,8 @@
 """jobs テスト共通フィクスチャ(T-013)。
 
-research/press と同流儀: ライブ PostgreSQL に対し実行し、接続不可なら skip、commit せず
-rollback で隔離する。**LLM は実プロバイダを呼ばない** — ``DryRunProvider`` を注入する。
+research/press と同流儀: テスト専用 DB(tests/conftest.py が用意)に対し実行し、
+接続不可なら skip、commit せず rollback で隔離する。**LLM は実プロバイダを呼ばない** —
+``DryRunProvider`` を注入する。
 """
 
 from __future__ import annotations
@@ -9,26 +10,13 @@ from __future__ import annotations
 import hashlib
 from datetime import UTC, datetime
 
-import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.provenance import start_run
 from ryza.research.llm import StructuredLLM
 from ryza.research.providers import DryRunProvider, LLMConfig
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/ledger/conftest.py
+++ b/tests/ledger/conftest.py
@@ -1,29 +1,16 @@
 """ledger テストの共通フィクスチャ。
 
-ライブ PostgreSQL(compose.yaml の DB)に対して実行する。接続できない場合は skip。
-各テストは関数スコープの接続を使い、commit せず rollback して隔離する(シードや他テストを汚さない)。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。
+接続できない場合は skip。各テストは関数スコープの接続を使い、commit せず rollback して
+隔離する(シードや他テストを汚さない)。
 """
 
 from __future__ import annotations
 
-import psycopg
 import pytest
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.ledger import create_run
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    """DB に接続できれば全マイグレーションを適用して yield。不可なら skip。"""
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/preprocess/conftest.py
+++ b/tests/preprocess/conftest.py
@@ -1,6 +1,6 @@
 """preprocess テスト共通フィクスチャ。
 
-ライブ PostgreSQL（compose.yaml の DB）に対して実行する。接続不可なら skip。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。接続不可なら skip。
 テストは commit せず rollback して隔離する（preprocess の各 API は渡された ``conn`` を
 commit しない）。**実埋め込みモデルはロードしない** — ``HashingEmbedder``（依存ゼロの
 決定論ダミー）を注入する（要件: フィクスチャはダミーベクトル）。
@@ -10,27 +10,13 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.preprocess.embed import HashingEmbedder
 from ryza.preprocess.importance import ImportanceConfig
 from ryza.provenance import start_run
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    """DB に接続できれば全マイグレーションを適用して yield。不可なら skip。"""
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/press/conftest.py
+++ b/tests/press/conftest.py
@@ -1,7 +1,8 @@
 """press テスト共通フィクスチャ(T-007/T-008)。
 
-research テストと同流儀: ライブ PostgreSQL に対し実行し、接続不可なら skip、commit せず
-rollback で隔離する。**LLM・画像 API・ネットワークは実呼び出ししない** — 構造化出力は
+research テストと同流儀: テスト専用 DB(tests/conftest.py が用意)に対し実行し、
+接続不可なら skip、commit せず rollback で隔離する。
+**LLM・画像 API・ネットワークは実呼び出ししない** — 構造化出力は
 ``PressEchoProvider``(素材の refs を反映した合法トピックを返す決定論プロバイダ)を注入し、
 画像は ``FakeHttp``(フィクスチャ post を返す)を使う。
 """
@@ -13,25 +14,12 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
-import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.provenance import start_run
 from ryza.research.llm import ProviderResult, StructuredLLM
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/provenance/conftest.py
+++ b/tests/provenance/conftest.py
@@ -1,29 +1,15 @@
 """provenance テスト共通フィクスチャ。
 
-ライブ PostgreSQL(compose.yaml の DB)に対して実行する。接続不可なら skip。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。接続不可なら skip。
 テストは commit せず rollback して隔離する。provenance の各 API は渡された ``conn`` を
 commit しないため、rollback フィクスチャだけで完全に隔離できる(runs / lineage も含む)。
 """
 
 from __future__ import annotations
 
-import psycopg
 import pytest
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    """DB に接続できれば全マイグレーションを適用して yield。不可なら skip。"""
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
+from ryza.db.conn import connect
 
 
 @pytest.fixture

--- a/tests/research/conftest.py
+++ b/tests/research/conftest.py
@@ -1,6 +1,6 @@
 """research テスト共通フィクスチャ(T-011)。
 
-ライブ PostgreSQL(compose.yaml の DB)に対して実行する。接続不可なら skip。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。接続不可なら skip。
 テストは commit せず rollback して隔離する(research の各 API は渡された ``conn`` を
 commit しない)。**LLM は実プロバイダを呼ばない** — ``FixtureProvider``(構造化出力の
 フィクスチャ)を注入する。
@@ -11,25 +11,12 @@ from __future__ import annotations
 import hashlib
 from datetime import UTC, datetime
 
-import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
-from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 from ryza.provenance import start_run
 from ryza.research.llm import FixtureProvider, StructuredLLM
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,7 +1,7 @@
 """T-001 受け入れ基準の自動検証。
 
-ライブ PostgreSQL（compose.yaml の DB）に対して実行する。DB に接続できない場合は
-全テストを skip する（Docker 未導入環境向け）。
+テスト専用 DB(tests/conftest.py の ``migrated_db`` が用意)に対して実行する。
+DB に接続できない場合は全テストを skip する（Docker 未導入環境向け）。
 
 前提: `docker compose up -d` 済み、または RYZA_DATABASE_URL が有効な DB を指す。
 """
@@ -12,7 +12,7 @@ import psycopg
 import pytest
 
 from ryza.db import migrate
-from ryza.db.conn import connect, database_url
+from ryza.db.conn import connect
 
 # 5 スキーマ・全テーブルの期待集合（設計書 §2〜§6）。
 EXPECTED_TABLES: dict[str, set[str]] = {
@@ -25,18 +25,6 @@ EXPECTED_TABLES: dict[str, set[str]] = {
         "nav_snapshots", "reconciliations", "budgets",
     },
 }
-
-
-@pytest.fixture(scope="session")
-def migrated_db():
-    """DB に接続できれば全マイグレーションを適用して yield。不可なら skip。"""
-    try:
-        with psycopg.connect(database_url(), connect_timeout=3):
-            pass
-    except Exception as exc:  # noqa: BLE001 - 接続不能は skip 理由として提示
-        pytest.skip(f"PostgreSQL に接続できないため skip: {exc}")
-    migrate.run()
-    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## 変更内容

DB 依存テスト(tests/ingest, tests/jobs ほか全 8 ディレクトリ + test_migrations.py)を、共有ローカル PostgreSQL(`ryza`)からテスト専用 DB(`ryza_test`)へ恒久的に隔離した。

- **tests/conftest.py**: `pytest_configure` で収集前に `RYZA_DATABASE_URL` をテスト専用 DB(元 dbname + `_test`)へ差し替え。共通化した `migrated_db` フィクスチャが管理接続で `CREATE DATABASE`(存在しなければ)+ 全マイグレーション適用を行う。`RYZA_TEST_DATABASE_URL` で明示上書き可
- 9 箇所に重複していた `migrated_db` フィクスチャを root conftest に統合(テスト本体のアサーションは無変更)
- `clear_residual`(トランザクション内 DELETE、rollback で巻き戻し)は並行テストセッション・誤 commit への第二層の保険として存置

## 背景

テストは共有 DB に対しテーブル全体の件数を数えるアサーション(例: `SELECT count(*) FROM docs.documents WHERE source_name='TDnet'`)を使っており、rollback 隔離はテスト自身の書込にしか効かない。別セッションやジョブが確定行を commit すると無関係なテストが壊れる(実例: 2026-08-03 の `issue23.residual-seed` Run が TDnet/FRB/EDINET 各 1 行を commit)。run_id スコープ化(対案)はアサーション書き換えが全域に波及し、triage_queue に他 run の行が載る等の件数以外の干渉経路を塞げないため、専用 DB 方式を採った。

## レビュー観点

- `ryza_test` は初回テスト実行時に自動作成され、以後は冪等マイグレーションで追随する。マイグレーションファイルを破壊的に書き換えた場合は手動 `DROP DATABASE ryza_test` が必要(次回実行で再作成)
- テスト実行は `uv run --extra dev pytest tests/`(pytest は dev extra のため `--extra dev` 必須)。手元で 418 件全て pass を確認済み
- T-012 の暫定回避 DB `ryza_t012` は DROP 済み(本 PR のコード変更外のサーバー操作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)