### PR TITLE
fix(ingest): TDnet 取込を日付範囲 RSS に変更し決算集中日の取りこぼしを解消

### DIFF
--- a/src/ryza/ingest/tdnet.py
+++ b/src/ryza/ingest/tdnet.py
@@ -1,21 +1,29 @@
 """ingest.tdnet — TDnet 適時開示 RSS の生取込。
 
-決算・業績修正・材料等の適時開示 RSS を 5 分間隔でポーリングする用途。**本タスクでは
-生取込のみ**（開示種別の辞書分類・銘柄タグ付けは階層0 前処理 T-010 の範囲）。各エントリを
+決算・業績修正・材料等の適時開示 RSS の取込。**本タスクでは生取込のみ**（開示種別の
+辞書分類・銘柄タグ付けは階層0 前処理 T-010 の範囲）。各エントリを
 ``docs.documents``（source_type='filing', source_name='TDnet'）へ冪等取込し、原文（エントリ
 XML 断片）を証憑ストアへ保存する。
 
 RSS 解析は ``base.parse_feed``（RSS/Atom 共通）。冪等キーはエントリの guid → link →
 title の優先で content_hash 化する。
 
-実行: ``python -m ryza.ingest.tdnet [--feed-url URL]``
+既定のフィード URL は **日付範囲指定**（対象日から ``--lookback-days`` 日前まで、
+``list/YYYYMMDD-YYYYMMDD.rss``）。決算集中日は 1 日 1000 件超の開示があり、直近 N 件を
+返す ``recent.rss`` では日次実行で取りこぼすため（検証: 2026-05-12 は 1146 件）。
+5 分間隔ポーリングへ移行する場合も、冪等取込のため同じ CLI をそのまま高頻度実行してよい
+（その場合は ``--feed-url``/env で ``recent.rss`` を指定した方が転送量が小さい）。
+
+実行: ``python -m ryza.ingest.tdnet [--date YYYY-MM-DD] [--lookback-days N]
+[--limit N] [--feed-url URL]``
 """
 
 from __future__ import annotations
 
 import argparse
 import os
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import psycopg
 
@@ -26,17 +34,57 @@ from ryza.provenance import EvidenceStore, Run
 from ryza.provenance import run as run_ctx
 
 SOURCE_NAME = "TDnet"
-# TDnet 適時開示情報の RSS。実 URL は運用時に環境変数で上書き可能にしておく。
-#
+JST = ZoneInfo("Asia/Tokyo")
+
 # TDnet 公式(release.tdnet.info)は HTML 閲覧のみで無料の RSS/API を提供していない
 # (公式 TDnet API と J-Quants の TDnet アドオンはいずれも有料)。ここでは準公式の
 # 「東証TDnet WEB-API by やのしん」(https://webapi.yanoshin.jp/tdnet/、公式 TDnet を
-# 数分間隔で同期)の RSS を既定とする(Issue #29)。個人運営サービスのため、停止時は
+# 数分間隔で同期)を既定とする(Issue #29)。個人運営サービスのため、停止時は
 # RYZA_TDNET_FEED_URL で代替 URL に切り替えるか、有料 API への移行を検討する。
-DEFAULT_FEED_URL = os.environ.get(
-    "RYZA_TDNET_FEED_URL",
-    "https://webapi.yanoshin.jp/webapi/tdnet/list/recent.rss?limit=200",
-)
+API_BASE = "https://webapi.yanoshin.jp/webapi/tdnet"
+
+# 1 リクエストの最大取得件数。API 既定は 300 件・決算集中日は 1 日 1000 件超のため、
+# 2 日分(範囲取得)でも全件収まる値にする(検証: limit=3000 で 2 日分 1851 件を一括返却)。
+DEFAULT_LIMIT = 3000
+
+# 対象日から何日さかのぼるか。日次実行(09:00 JST)では前日 15〜17 時の開示集中帯が
+# 朝刊の主材料になるため、既定で前日を含める(冪等取込のため重複取得は無害)。
+DEFAULT_LOOKBACK_DAYS = 1
+
+
+def feed_url_for(
+    target_date: date,
+    *,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    limit: int = DEFAULT_LIMIT,
+) -> str:
+    """対象日(+ルックバック)の全開示を返す日付範囲 RSS の URL を組む。"""
+    start = target_date - timedelta(days=lookback_days)
+    cond = (
+        f"{start:%Y%m%d}-{target_date:%Y%m%d}"
+        if start != target_date
+        else f"{target_date:%Y%m%d}"
+    )
+    return f"{API_BASE}/list/{cond}.rss?limit={limit}"
+
+
+def resolve_feed_url(
+    *,
+    feed_url: str | None = None,
+    date_str: str | None = None,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    limit: int = DEFAULT_LIMIT,
+) -> str:
+    """フィード URL を決める。優先度: ``--feed-url`` > env > 日付範囲の既定 URL。"""
+    if feed_url:
+        return feed_url
+    env_url = os.environ.get("RYZA_TDNET_FEED_URL")
+    if env_url:
+        return env_url
+    target = (
+        date.fromisoformat(date_str) if date_str else datetime.now(JST).date()
+    )
+    return feed_url_for(target, lookback_days=lookback_days, limit=limit)
 
 
 def _entry_key(item: base.FeedItem) -> str:
@@ -49,7 +97,7 @@ def ingest_feed(
     store: EvidenceStore,
     fetcher: Fetcher,
     *,
-    feed_url: str = DEFAULT_FEED_URL,
+    feed_url: str,
     as_of: datetime | None = None,
 ) -> dict[str, int]:
     """RSS を取得・解析し ``docs.documents`` へ冪等取込する。``{'written', 'total'}``。"""
@@ -78,15 +126,33 @@ def ingest_feed(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="TDnet 適時開示 RSS 取込")
-    parser.add_argument("--feed-url", default=DEFAULT_FEED_URL)
+    parser.add_argument(
+        "--date", default=None, help="対象日(JST, YYYY-MM-DD)。既定は今日"
+    )
+    parser.add_argument(
+        "--lookback-days", type=int, default=DEFAULT_LOOKBACK_DAYS,
+        help=f"対象日から何日さかのぼるか(既定 {DEFAULT_LOOKBACK_DAYS})",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=DEFAULT_LIMIT,
+        help=f"最大取得件数(既定 {DEFAULT_LIMIT})",
+    )
+    parser.add_argument(
+        "--feed-url", default=None,
+        help="フィード URL の明示指定(日付指定・env より優先)",
+    )
     args = parser.parse_args(argv)
+    feed_url = resolve_feed_url(
+        feed_url=args.feed_url, date_str=args.date,
+        lookback_days=args.lookback_days, limit=args.limit,
+    )
 
     store = base.default_store()
     fetcher = base.default_fetcher()
     conn = connect(autocommit=True)
     try:
-        with run_ctx("ingest.tdnet.rss", {"feed_url": args.feed_url}, conn=conn) as r:
-            result = ingest_feed(conn, r, store, fetcher, feed_url=args.feed_url)
+        with run_ctx("ingest.tdnet.rss", {"feed_url": feed_url}, conn=conn) as r:
+            result = ingest_feed(conn, r, store, fetcher, feed_url=feed_url)
         print(f"tdnet rss: {result}")
     finally:
         conn.close()

--- a/src/ryza/jobs/daily.py
+++ b/src/ryza/jobs/daily.py
@@ -83,7 +83,9 @@ def _default_ingest_sources() -> list[tuple[str, IngestSource]]:
 
     return [
         ("jquants", lambda as_of: jquants.main(["--date", _date(as_of)])),
-        ("tdnet", lambda as_of: tdnet.main([])),
+        # tdnet は日付範囲取得(対象日+前日)。recent.rss だと決算集中日(1000件超/日)に
+        # 日次 1 回の実行では取りこぼすため(tdnet.py の既定 URL 参照)。
+        ("tdnet", lambda as_of: tdnet.main(["--date", _date(as_of)])),
         ("edinet", lambda as_of: edinet.main(["--date", _date(as_of)])),
         ("news_rss", lambda as_of: news_rss.main([])),
         ("fred", lambda as_of: fred.main([])),

--- a/tests/ingest/test_tdnet.py
+++ b/tests/ingest/test_tdnet.py
@@ -1,6 +1,8 @@
-"""TDnet RSS 取込テスト（HTTP 全モック）。正常・重複・異常。"""
+"""TDnet RSS 取込テスト（HTTP 全モック）。正常・重複・異常・URL 構築。"""
 
 from __future__ import annotations
+
+from datetime import date
 
 import pytest
 
@@ -58,3 +60,32 @@ def test_evidence_saved_for_entry(conn, run, store, fetcher):
     with conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM ledger.evidence WHERE kind='tdnet_rss'")
         assert cur.fetchone()[0] == 2
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# フィード URL 構築（日付範囲指定。決算集中日 1000 件超/日の取りこぼし対策）
+# ────────────────────────────────────────────────────────────────────────────
+def test_feed_url_for_range():
+    url = tdnet.feed_url_for(date(2026, 5, 12))
+    assert url == "https://webapi.yanoshin.jp/webapi/tdnet/list/20260511-20260512.rss?limit=3000"
+
+
+def test_feed_url_for_single_day():
+    url = tdnet.feed_url_for(date(2026, 5, 12), lookback_days=0, limit=500)
+    assert url == "https://webapi.yanoshin.jp/webapi/tdnet/list/20260512.rss?limit=500"
+
+
+def test_resolve_feed_url_explicit_wins(monkeypatch):
+    monkeypatch.setenv("RYZA_TDNET_FEED_URL", "http://env/feed.rss")
+    assert tdnet.resolve_feed_url(feed_url="http://cli/feed.rss") == "http://cli/feed.rss"
+
+
+def test_resolve_feed_url_env_over_default(monkeypatch):
+    monkeypatch.setenv("RYZA_TDNET_FEED_URL", "http://env/feed.rss")
+    assert tdnet.resolve_feed_url(date_str="2026-05-12") == "http://env/feed.rss"
+
+
+def test_resolve_feed_url_default_is_date_range(monkeypatch):
+    monkeypatch.delenv("RYZA_TDNET_FEED_URL", raising=False)
+    url = tdnet.resolve_feed_url(date_str="2026-05-12")
+    assert url == tdnet.feed_url_for(date(2026, 5, 12))


### PR DESCRIPTION
## 変更内容

- `src/ryza/ingest/tdnet.py`: 既定フィード URL を `recent.rss?limit=200` から日付範囲指定 `list/YYYYMMDD-YYYYMMDD.rss?limit=3000`(対象日+ルックバック 1 日)に変更。URL 構築の `feed_url_for` / 優先度解決の `resolve_feed_url` を追加し、CLI に `--date` / `--lookback-days` / `--limit` を追加
- `src/ryza/jobs/daily.py`: tdnet ソースの呼び出しを `tdnet.main(["--date", _date(as_of)])` に変更(他ソースと同じ日付受け渡し)
- `tests/ingest/test_tdnet.py`: URL 構築・優先度解決(明示指定 > env > 既定)のテスト 5 件を追加

## 背景・理由

daily は tdnet を 1 日 1 回しか呼ばないが、決算集中日は 1 日 1000 件超の開示がある。実 API での検証: 2026-05-12 は **1146 件**で、`recent.rss?limit=200` では 8 割超を取りこぼす。日付指定エンドポイントは `limit=3000` で 2 日分 1851 件を一括返却できることを確認済み(Issue #29 の準公式 API の範囲内)。

ルックバック 1 日の理由: daily は 09:00 JST 起動のため、朝刊の主材料である前日 15〜17 時の開示集中帯を範囲に含める必要がある。冪等取込(`content_hash`)のため前日分の重複取得は無害。

## レビュー観点

- `--feed-url` / `RYZA_TDNET_FEED_URL` による上書きは維持(やのしん API 停止時の代替切替)。優先度は 明示指定 > env > 日付範囲既定
- `ingest_feed` の `feed_url` 引数は既定値を外し必須化(参照は tdnet.py 内と tests のみで、全呼び出しが明示指定であることを確認済み)
- 5 分ポーリング(docstring が想定する本来運用)は今回見送り: 下流の分析・朝刊が日次のため鮮度向上の受け手がなく、VM 内 DB のため Cloud Scheduler からも届かない。冪等 CLI のため、日中運用開始時に systemd timer を足すだけで移行可能
- 留保: やのしん API の limit 上限は未文書化(3000 で動作確認済みだが、将来 JSON の `total_count` との突合による欠落検知を堅牢化候補とする)

## テスト

- `uv run pytest tests/ingest/test_tdnet.py tests/jobs/test_daily.py` → 19 passed(ライブ PostgreSQL 込み)
- `uv run ruff check` 合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)