### PR TITLE
fix(tests): ingest テストの件数アサートを自 run_id に限定

### DIFF
--- a/tests/ingest/test_base.py
+++ b/tests/ingest/test_base.py
@@ -92,10 +92,12 @@ def test_write_bar_idempotent(conn, run):
     assert base.write_bar(conn, run, **kw) is True
     assert base.write_bar(conn, run, **kw) is False  # 同一 PK は無視
 
+    # 共有 dev DB に実データが残っていても壊れないよう、自 run の書込分に絞って数える。
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT count(*) FROM market.bars WHERE instrument_id=%s AND source='jquants'",
-            (instrument_id,),
+            "SELECT count(*) FROM market.bars "
+            "WHERE instrument_id=%s AND source='jquants' AND run_id=%s",
+            (instrument_id, run.run_id),
         )
         assert cur.fetchone()[0] == 1
 

--- a/tests/ingest/test_jquants.py
+++ b/tests/ingest/test_jquants.py
@@ -92,11 +92,12 @@ def test_ingest_daily_quotes_writes_bars_with_lineage(conn, run, store):
         )
         assert cur.fetchone()[0] == 2
 
-    # 各バーに証憑リネージ辺。
+    # 各バーに証憑リネージ辺(共有 DB の既存辺と区別するため自 run に絞る)。
     with conn.cursor() as cur:
         cur.execute(
             "SELECT count(*) FROM meta.lineage_edges "
-            "WHERE from_kind='bars' AND to_kind='evidence'"
+            "WHERE from_kind='bars' AND to_kind='evidence' AND run_id=%s",
+            (run.run_id,),
         )
         assert cur.fetchone()[0] == 2
 
@@ -112,7 +113,8 @@ def test_ingest_daily_quotes_maps_v2_ohlcv(conn, run, store):
         cur.execute(
             "SELECT open, high, low, close, volume FROM market.bars b "
             "JOIN market.instruments i USING (instrument_id) "
-            "WHERE i.symbol='7203.T' AND b.source='jquants'"
+            "WHERE i.symbol='7203.T' AND b.source='jquants' AND b.run_id=%s",
+            (run.run_id,),
         )
         assert cur.fetchone() == (100, 110, 95, 105, 1000)
 
@@ -125,7 +127,10 @@ def test_ingest_daily_quotes_idempotent(conn, run, store):
     assert r1["written"] == 2
     assert r2["written"] == 0  # 同一 PK は増えない
     with conn.cursor() as cur:
-        cur.execute("SELECT count(*) FROM market.bars WHERE source='jquants'")
+        cur.execute(
+            "SELECT count(*) FROM market.bars WHERE source='jquants' AND run_id=%s",
+            (run.run_id,),
+        )
         assert cur.fetchone()[0] == 2
 
 


### PR DESCRIPTION
## 何を変えたか

`tests/ingest/test_base.py` と `tests/ingest/test_jquants.py` の4テストで、`market.bars` / `meta.lineage_edges` に対する絶対件数アサートを、各テスト自身の Run(`run_id`)の書込分に限定するフィルタに変更した。

- `test_write_bar_idempotent` — bars 件数を `instrument_id + run_id` で限定
- `test_ingest_daily_quotes_writes_bars_with_lineage` — lineage 辺の件数を `run_id` で限定
- `test_ingest_daily_quotes_maps_v2_ohlcv` — OHLCV 検証の行選択に `b.run_id` を追加(複数行あると `fetchone()` が任意の行を返すため)
- `test_ingest_daily_quotes_idempotent` — bars 件数を `run_id` で限定

## なぜ

共有 dev DB(`postgresql://ryza:ryza@localhost:5432/ryza`)に前回セッションの実 J-Quants ingest データ(`market.bars` に `source='jquants'` 4449行)が残っており、テーブル全体の絶対件数(`==2` 等)を見るアサートが破綻していた。rollback 隔離は「テストが commit しない」ことしか保証せず、事前投入データとの共存は件数アサート側の責務。

取込基盤の規約で全書込行に `run_id` が刻まれ、テストごとの `run` フィクスチャは一意な Run を作るため、`run_id` フィルタだけで「自分の書込分」に正確に絞れる。DB truncate や専用 instrument 方式より差分が小さい。

## レビュー時の補足

- 書き込み側(`written` 件数)は元々壊れていない: `market.bars` の PK は `as_of` を含み、テストの `as_of=now()` は実データと衝突しない
- 検証: `uv run pytest tests/ingest/ -q` 48件 / 全体154件が実データ入り dev DB で緑
- 既知の残存リスク: `test_ingest_statements_as_documents` は `source_name='J-Quants'` のみで `docs.documents` を引いており、将来実 DB に財務諸表 ingest が入ると同種の破綻をする(現状は bars のみのため緑)。本 PR のスコープ外として未修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)