### PR TITLE
audit(a13): A-13-4 全変更PR化の検査(直push・非PRマージ検出)(保護領域・みなし承認)

### DIFF
--- a/config/governance.yaml
+++ b/config/governance.yaml
@@ -180,8 +180,3 @@ controls:
     enforcement: declaration # 役員室実装時に決議フローで強制
     kind: 予防
     verification: 同上
-  - rule: 開発管理(全変更 PR 化 — 2026-08-03 代表指示。保護領域に限らず全変更を PR 経由とする)
-    risk: レビューを経ない直 push で main が変更される(保護領域外の変更もレビュー対象)
-    enforcement: audit # GitHub 無料プラン(私有リポ)はブランチ保護が使えないため本監査が執行点
-    kind: 発見
-    verification: 基準コミット(a13.PR_RULE_BASELINE_COMMIT = ルール採用日の main HEAD)以降の main first-parent 履歴で、マージコミットでないコミット(= 直 push)を列挙(A-13-4)。例外なし — Approved トレーラ付き直 push も違反。基準以前は対象外

--- a/config/governance.yaml
+++ b/config/governance.yaml
@@ -180,3 +180,8 @@ controls:
     enforcement: declaration # 役員室実装時に決議フローで強制
     kind: 予防
     verification: 同上
+  - rule: 開発管理(全変更 PR 化 — 2026-08-03 代表指示。保護領域に限らず全変更を PR 経由とする)
+    risk: レビューを経ない直 push で main が変更される(保護領域外の変更もレビュー対象)
+    enforcement: audit # GitHub 無料プラン(私有リポ)はブランチ保護が使えないため本監査が執行点
+    kind: 発見
+    verification: 基準コミット(a13.PR_RULE_BASELINE_COMMIT = ルール採用日の main HEAD)以降の main first-parent 履歴で、マージコミットでないコミット(= 直 push)を列挙(A-13-4)。例外なし — Approved トレーラ付き直 push も違反。基準以前は対象外

--- a/src/ryza/audit/a13.py
+++ b/src/ryza/audit/a13.py
@@ -1,6 +1,6 @@
 """A-13 規則⇔実装トレーサビリティ監査(定款第6条・config/governance.yaml controls)。
 
-3つの検査を実行し、構造化 dict を返す:
+4つの検査を実行し、構造化 dict を返す:
 
   A-13-1 保護領域突合   … `protected_areas` の glob に触れた発効日以後のコミットを列挙し、
                           (a) ``Approved:`` トレーラ (b) GitHub マージ PR 経由(Merge pull request
@@ -9,6 +9,10 @@
                           のバージョン文字列一致を検査する
   A-13-3 宣言棚卸し     … controls のうち ``enforcement: declaration`` を列挙する(検査ではなく
                           可視化 — 四半期ごとの執行点実装可否の再評価対象)
+  A-13-4 全変更 PR 化   … 基準コミット(``PR_RULE_BASELINE_COMMIT``)以降の first-parent 履歴で、
+                          マージコミットでないコミット(= main への直 push)を保護領域か否かに
+                          かかわらず違反として列挙する。例外なし(``Approved:`` トレーラ付き
+                          直 push も違反 — 2026-08-03 代表指示)
 
 **read-only 原則**: 本モジュールは検査と警告(``press.outbox`` の ops チャンネルへの embed 投入)
 のみを行い、修正・巻き戻し・コミットは一切行わない。
@@ -56,6 +60,13 @@ log = logging.getLogger("ryza.audit.a13")
 # 定款批准コミット(2026-08-03 発効・Merge pull request #32)。これ以前は監査対象外。
 RATIFICATION_COMMIT = "c7af81ef85cc9f45bb7881ffc45769abfbc771dc"
 
+# 全変更 PR 化ルール(2026-08-03 代表指示: 保護領域に限らずリポジトリへの全変更を PR 経由と
+# する)の基準コミット = ルール採用日(A-13-4 実装時点)の origin/main HEAD。
+#   4c7f6e9 "docs(tasks): T-017 FM エージェント第一陣(Ben・Jim)の実装指示書"
+# これ以前の直 push は対象外(遡及しない)。GitHub 無料プラン(私有リポ)ではブランチ保護が
+# 使えないため、本監査(A-13-4)がこのルールの執行点になる。
+PR_RULE_BASELINE_COMMIT = "4c7f6e9daded18a3e9e903a80c87feba3576b52c"
+
 GOVERNANCE_PATH = "config/governance.yaml"
 
 # 既知の限界の常時開示(独立役員審査条件)。報告 embed の notes に毎回載せる。
@@ -64,6 +75,8 @@ STANDARD_DISCLOSURES: tuple[str, ...] = (
     "Approved トレーラの参照先(Issue / governance.decisions)の実在は未照合",
     "マージのコンフリクト解消差分(evil merge)は --cc で検査し、保護パスに触れる場合は"
     "マージ自身の Approved トレーラを要求",
+    "A-13-4 はコミットの親数のみで直 push を判定 — ローカルで作った非 PR マージの直 push は"
+    "検出できない(保護パスに触れる場合は A-13-1 が PR 件名で検出)",
 )
 
 # 文書⇔config のバージョン突合ペア(A-13-2)。(文書, config, config 内の version キー)
@@ -329,6 +342,49 @@ def _staleness_note(repo_path: str | Path) -> list[str]:
 
 
 # ────────────────────────────────────────────────────────────────────────────
+# A-13-4 全変更 PR 化(直 push 検査)
+# ────────────────────────────────────────────────────────────────────────────
+def check_direct_pushes(
+    repo_path: str | Path,
+    *,
+    since_commit: str | None = PR_RULE_BASELINE_COMMIT,
+) -> tuple[list[dict[str, Any]], int]:
+    """A-13-4: main への直 push の一覧と、検査した first-parent コミット数を返す。
+
+    基準コミット(全変更 PR 化ルール採用日の main HEAD)以降の first-parent 履歴で、
+    マージコミットでないコミット = 直 push を違反とする。保護領域か否かは問わず、
+    例外も設けない(``Approved:`` トレーラ付き直 push も違反 — 全 PR 化ルールに例外なし)。
+    基準コミット以前は ``rev-list since..HEAD`` により対象外。
+    """
+    repo = str(repo_path)
+    if since_commit and not _git_ok(repo, "cat-file", "-e", f"{since_commit}^{{commit}}"):
+        raise ValueError(f"全変更 PR 化の基準コミットがリポジトリに存在しない: {since_commit}")
+
+    fp_commits = _rev_list(repo, since_commit, "--first-parent")
+    violations: list[dict[str, Any]] = []
+    for sha in fp_commits:
+        parents = _git(repo, "log", "-1", "--format=%P", sha).split()
+        if len(parents) > 1:
+            continue  # マージコミット = PR マージ経由(件名検査は A-13-1 の責務)
+        files = [
+            ln
+            for ln in _git(
+                repo, "diff-tree", "--no-commit-id", "--name-only", "-r", "--root", sha
+            ).splitlines()
+            if ln
+        ]
+        violations.append(
+            {
+                "commit": sha[:12],
+                "subject": _git(repo, "log", "-1", "--format=%s", sha).strip(),
+                "files": files,
+                "reason": "main への直 push(全変更 PR 化ルール違反 — 例外なし)",
+            }
+        )
+    return violations, len(fp_commits)
+
+
+# ────────────────────────────────────────────────────────────────────────────
 # 本体・報告
 # ────────────────────────────────────────────────────────────────────────────
 def run_a13(
@@ -336,11 +392,13 @@ def run_a13(
     *,
     governance_path: str = GOVERNANCE_PATH,
     since_commit: str | None = RATIFICATION_COMMIT,
+    pr_since_commit: str | None = PR_RULE_BASELINE_COMMIT,
     version_pairs: tuple[tuple[str, str], ...] = VERSION_PAIRS,
 ) -> dict[str, Any]:
-    """A-13 の3検査を実行して構造化 dict を返す(DB・Discord に依存しない純検査)。"""
+    """A-13 の4検査を実行して構造化 dict を返す(DB・Discord に依存しない純検査)。"""
     gov = load_governance(repo_path, governance_path)
     violations, checked = check_protected_commits(repo_path, gov, since_commit=since_commit)
+    direct_pushes, fp_checked = check_direct_pushes(repo_path, since_commit=pr_since_commit)
     return {
         "as_of": datetime.now(UTC).isoformat(),
         "since_commit": since_commit,
@@ -348,6 +406,9 @@ def run_a13(
         "violations": violations,
         "mismatches": check_versions(repo_path, version_pairs),
         "declarations": list_declarations(gov),
+        "pr_since_commit": pr_since_commit,
+        "checked_first_parent": fp_checked,
+        "direct_pushes": direct_pushes,
         # 既知の限界は毎回開示する(独立役員審査条件)+ 個別の注記(登録漏れ・鮮度)。
         "notes": [
             *_coverage_notes(gov),
@@ -359,7 +420,7 @@ def run_a13(
 
 def has_findings(result: dict[str, Any]) -> bool:
     """警告(embed 投入)を要する所見があるか。"""
-    return bool(result["violations"] or result["mismatches"])
+    return bool(result["violations"] or result["mismatches"] or result["direct_pushes"])
 
 
 def build_alert_embed(result: dict[str, Any]) -> dict[str, Any]:
@@ -412,6 +473,27 @@ def build_alert_embed(result: dict[str, Any]) -> dict[str, Any]:
             "inline": False,
         }
     )
+
+    if result["direct_pushes"]:
+        lines = [
+            f"- `{v['commit']}` {v['subject']}({', '.join(v['files'])})"
+            for v in result["direct_pushes"]
+        ]
+        fields.append(
+            {
+                "name": "⚠️ A-13-4 main への直 push(全変更 PR 化ルール違反)",
+                "value": "\n".join(lines)[:1024],
+                "inline": False,
+            }
+        )
+    else:
+        fields.append(
+            {
+                "name": "A-13-4 全変更 PR 化",
+                "value": f"✅ 直 push なし(検査 {result['checked_first_parent']} コミット)",
+                "inline": False,
+            }
+        )
     if result["notes"]:
         notes_value = "\n".join(f"- {n}" for n in result["notes"])[:1024]
         fields.append({"name": "注記", "value": notes_value, "inline": False})
@@ -430,9 +512,8 @@ def build_alert_embed(result: dict[str, Any]) -> dict[str, Any]:
 
 def enqueue_alert(conn: Any, result: dict[str, Any], run_id: int, *, channel: str = "ops") -> int:
     """検査結果 embed を ``press.outbox`` の ops チャンネルへ投入する(違反時は urgent)。"""
-    return enqueue(
-        conn, channel, build_alert_embed(result), run_id, urgent=bool(result["violations"])
-    )
+    urgent = bool(result["violations"] or result["direct_pushes"])
+    return enqueue(conn, channel, build_alert_embed(result), run_id, urgent=urgent)
 
 
 def run_and_report(
@@ -441,17 +522,20 @@ def run_and_report(
     dry_run: bool = False,
     always_report: bool = False,
     since_commit: str | None = RATIFICATION_COMMIT,
+    pr_since_commit: str | None = PR_RULE_BASELINE_COMMIT,
 ) -> dict[str, Any]:
     """A-13 を実行し、所見があれば(または ``always_report``)#運営 へ enqueue する。
 
     ops-weekly など他ジョブからの呼び出し口。``dry_run`` では DB に接続せずログのみ。
     """
-    result = run_a13(repo_path, since_commit=since_commit)
+    result = run_a13(repo_path, since_commit=since_commit, pr_since_commit=pr_since_commit)
     report = has_findings(result) or always_report
     if dry_run:
         log.info(
-            "[DRY_RUN] A-13 結果: violations=%d mismatches=%d declarations=%d(enqueue %s)",
+            "[DRY_RUN] A-13 結果: violations=%d mismatches=%d declarations=%d "
+            "direct_pushes=%d(enqueue %s)",
             len(result["violations"]), len(result["mismatches"]), len(result["declarations"]),
+            len(result["direct_pushes"]),
             "対象" if report else "不要",
         )
         return result
@@ -497,9 +581,12 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - CLI 実行
     for m in result["mismatches"]:
         print(f"[不整合] {m['doc']} v{m['doc_version']} ⇔ {m['config']} v{m['config_version']}",
               file=sys.stderr)
+    for d in result["direct_pushes"]:
+        print(f"[直push] {d['commit']} {d['subject']}: {d['files']}", file=sys.stderr)
     print(
         f"A-13 完了(検査 {result['checked_commits']} コミット, 違反 {len(result['violations'])}, "
-        f"不整合 {len(result['mismatches'])}, 宣言 {len(result['declarations'])})",
+        f"不整合 {len(result['mismatches'])}, 宣言 {len(result['declarations'])}, "
+        f"直push {len(result['direct_pushes'])})",
         file=sys.stderr,
     )
     return 1 if has_findings(result) else 0

--- a/src/ryza/audit/a13.py
+++ b/src/ryza/audit/a13.py
@@ -10,9 +10,10 @@
   A-13-3 宣言棚卸し     … controls のうち ``enforcement: declaration`` を列挙する(検査ではなく
                           可視化 — 四半期ごとの執行点実装可否の再評価対象)
   A-13-4 全変更 PR 化   … 基準コミット(``PR_RULE_BASELINE_COMMIT``)以降の first-parent 履歴で、
-                          マージコミットでないコミット(= main への直 push)を保護領域か否かに
-                          かかわらず違反として列挙する。例外なし(``Approved:`` トレーラ付き
-                          直 push も違反 — 2026-08-03 代表指示)
+                          (a) マージコミットでないコミット(= main への直 push)
+                          (b) 件名が PR マージ形式(``Merge pull request``)でないマージコミット
+                          を保護領域か否かにかかわらず違反として列挙する。例外なし
+                          (``Approved:`` トレーラ付き直 push も違反 — 2026-08-03 代表指示)
 
 **read-only 原則**: 本モジュールは検査と警告(``press.outbox`` の ops チャンネルへの embed 投入)
 のみを行い、修正・巻き戻し・コミットは一切行わない。
@@ -75,8 +76,8 @@ STANDARD_DISCLOSURES: tuple[str, ...] = (
     "Approved トレーラの参照先(Issue / governance.decisions)の実在は未照合",
     "マージのコンフリクト解消差分(evil merge)は --cc で検査し、保護パスに触れる場合は"
     "マージ自身の Approved トレーラを要求",
-    "A-13-4 はコミットの親数のみで直 push を判定 — ローカルで作った非 PR マージの直 push は"
-    "検出できない(保護パスに触れる場合は A-13-1 が PR 件名で検出)",
+    "A-13-4 のマージ判定は親数+PR 件名(A-13-1 と同一の検査)— 件名は自己申告で"
+    "GitHub API 未照合の限界を共有する",
 )
 
 # 文書⇔config のバージョン突合ペア(A-13-2)。(文書, config, config 内の version キー)
@@ -349,12 +350,14 @@ def check_direct_pushes(
     *,
     since_commit: str | None = PR_RULE_BASELINE_COMMIT,
 ) -> tuple[list[dict[str, Any]], int]:
-    """A-13-4: main への直 push の一覧と、検査した first-parent コミット数を返す。
+    """A-13-4: main への直 push・非 PR マージの一覧と、検査した first-parent コミット数を返す。
 
     基準コミット(全変更 PR 化ルール採用日の main HEAD)以降の first-parent 履歴で、
-    マージコミットでないコミット = 直 push を違反とする。保護領域か否かは問わず、
-    例外も設けない(``Approved:`` トレーラ付き直 push も違反 — 全 PR 化ルールに例外なし)。
-    基準コミット以前は ``rev-list since..HEAD`` により対象外。
+    (a) マージコミットでないコミット = 直 push、(b) 件名が PR マージ形式
+    (``_PR_MERGE_RE``、A-13-1 と同一の検査)でないマージコミット = 非 PR マージ、
+    を違反とする。保護領域か否かは問わず、例外も設けない(``Approved:`` トレーラ付き
+    直 push も違反 — 全 PR 化ルールに例外なし)。基準コミット以前は
+    ``rev-list since..HEAD`` により対象外。
     """
     repo = str(repo_path)
     if since_commit and not _git_ok(repo, "cat-file", "-e", f"{since_commit}^{{commit}}"):
@@ -365,20 +368,23 @@ def check_direct_pushes(
     for sha in fp_commits:
         parents = _git(repo, "log", "-1", "--format=%P", sha).split()
         if len(parents) > 1:
-            continue  # マージコミット = PR マージ経由(件名検査は A-13-1 の責務)
-        files = [
-            ln
-            for ln in _git(
-                repo, "diff-tree", "--no-commit-id", "--name-only", "-r", "--root", sha
-            ).splitlines()
-            if ln
-        ]
+            if _PR_MERGE_RE.match(_git(repo, "log", "-1", "--format=%s", sha)):
+                continue  # PR マージコミット(件名は自己申告 — 開示のとおり API 未照合)
+            reason = "main への非 PR マージ(全変更 PR 化ルール違反 — 例外なし)"
+            # マージが main に持ち込んだ内容 = first parent との差分を列挙する。
+            diff_args = (
+                "diff-tree", "--no-commit-id", "--name-only", "-r", "-m", "--first-parent", sha
+            )
+        else:
+            reason = "main への直 push(全変更 PR 化ルール違反 — 例外なし)"
+            diff_args = ("diff-tree", "--no-commit-id", "--name-only", "-r", "--root", sha)
+        files = [ln for ln in _git(repo, *diff_args).splitlines() if ln]
         violations.append(
             {
                 "commit": sha[:12],
                 "subject": _git(repo, "log", "-1", "--format=%s", sha).strip(),
                 "files": files,
-                "reason": "main への直 push(全変更 PR 化ルール違反 — 例外なし)",
+                "reason": reason,
             }
         )
     return violations, len(fp_commits)
@@ -481,7 +487,7 @@ def build_alert_embed(result: dict[str, Any]) -> dict[str, Any]:
         ]
         fields.append(
             {
-                "name": "⚠️ A-13-4 main への直 push(全変更 PR 化ルール違反)",
+                "name": "⚠️ A-13-4 全変更 PR 化違反(直 push・非 PR マージ)",
                 "value": "\n".join(lines)[:1024],
                 "inline": False,
             }
@@ -490,7 +496,9 @@ def build_alert_embed(result: dict[str, Any]) -> dict[str, Any]:
         fields.append(
             {
                 "name": "A-13-4 全変更 PR 化",
-                "value": f"✅ 直 push なし(検査 {result['checked_first_parent']} コミット)",
+                "value": (
+                    f"✅ 直 push・非 PR マージなし(検査 {result['checked_first_parent']} コミット)"
+                ),
                 "inline": False,
             }
         )

--- a/tests/audit/test_a13.py
+++ b/tests/audit/test_a13.py
@@ -2,7 +2,11 @@
 
 一時 git リポジトリを作り、保護領域突合(A-13-1)を承認あり/なし/PR マージ/発効日前の
 4 象限で検証する。バージョン整合(A-13-2)・宣言棚卸し(A-13-3)はフィクスチャファイルで、
-outbox 投入はテスト専用 DB で検証する。
+outbox 投入はテスト専用 DB で検証する。全変更 PR 化(A-13-4)は PR マージのみ/直 push/
+基準以前の3象限+例外なし(Approved トレーラ付き直 push も違反)を検証する。
+
+一時リポジトリでは実リポジトリの基準コミット(``PR_RULE_BASELINE_COMMIT``)が存在しない
+ため、``run_a13`` には ``pr_since_commit`` を明示的に渡す。
 """
 
 from __future__ import annotations
@@ -204,6 +208,76 @@ def test_glob_to_regex_semantics():
 
 
 # ────────────────────────────────────────────────────────────────────────────
+# A-13-4 全変更 PR 化(直 push 検査)
+# ────────────────────────────────────────────────────────────────────────────
+def _merge_pr(r: Path, branch: str, path: str, content: str, pr_no: int) -> None:
+    """ブランチにコミットを作り PR マージ(Merge pull request マージコミット)で main へ取り込む。"""
+    _git(r, "checkout", "-q", "-b", branch)
+    _commit(r, path, content, f"feat: {branch} の作業")
+    _git(r, "checkout", "-q", "main")
+    _git(r, "merge", "--no-ff", "-q", branch, "-m", f"Merge pull request #{pr_no} from k/{branch}")
+
+
+def test_a134_pr_merges_only_is_clean(repo):
+    """PR マージのみの履歴は違反 0。検査数はマージコミット(first-parent)のみ数える。"""
+    r, since = repo
+    _merge_pr(r, "f1", "README.md", "a\n", 1)
+    _merge_pr(r, "f2", "src/app.py", "x = 1\n", 2)
+    violations, checked = a13.check_direct_pushes(r, since_commit=since)
+    assert violations == []
+    assert checked == 2  # マージコミット2つ(ブランチ内コミットは first-parent でない)
+
+
+def test_a134_direct_push_is_violation(repo):
+    """保護領域外のファイルでも main への直 push は違反(全変更が対象)。"""
+    r, since = repo
+    sha = _commit(r, "README.md", "x\n", "docs: 直 push(保護領域外)")
+    violations, checked = a13.check_direct_pushes(r, since_commit=since)
+    assert checked == 1
+    assert [v["commit"] for v in violations] == [sha[:12]]
+    assert violations[0]["files"] == ["README.md"]
+    assert "直 push" in violations[0]["reason"]
+
+
+def test_a134_approved_trailer_is_still_violation(repo):
+    """例外なし: Approved トレーラ付きの直 push も違反(全 PR 化ルールに例外を設けない)。"""
+    r, since = repo
+    _commit(
+        r, "README.md", "x\n",
+        "docs: 承認トレーラ付き直 push\n\nApproved: https://github.com/x/y/issues/1",
+    )
+    violations, _ = a13.check_direct_pushes(r, since_commit=since)
+    assert len(violations) == 1
+
+
+def test_a134_pre_baseline_commits_are_excluded(repo):
+    """基準コミット以前の直 push は対象外(遡及しない)。since=None だと対象になる。"""
+    r, since = repo
+    violations, checked = a13.check_direct_pushes(r, since_commit=since)
+    assert violations == [] and checked == 0
+    # since=None なら全履歴が対象になり、基準以前の直 push(発効前コミット等)が検出される。
+    violations_all, _ = a13.check_direct_pushes(r, since_commit=None)
+    assert len(violations_all) == 2  # フィクスチャの pre コミット+批准コミット
+
+
+def test_a134_mixed_history_detects_only_direct_pushes(repo):
+    """PR マージと直 push の混在履歴で直 push だけを検出する。"""
+    r, since = repo
+    _merge_pr(r, "f1", "README.md", "a\n", 1)
+    direct = _commit(r, "docs/note.md", "n\n", "docs: 直 push")
+    _merge_pr(r, "f2", "src/app.py", "x = 1\n", 2)
+    violations, checked = a13.check_direct_pushes(r, since_commit=since)
+    assert checked == 3
+    assert [v["commit"] for v in violations] == [direct[:12]]
+
+
+def test_a134_unknown_since_commit_raises(repo):
+    r, _ = repo
+    with pytest.raises(ValueError):
+        a13.check_direct_pushes(r, since_commit="deadbeef" * 5)
+
+
+# ────────────────────────────────────────────────────────────────────────────
 # A-13-2 文書⇔config 整合
 # ────────────────────────────────────────────────────────────────────────────
 def _write(root: Path, rel: str, text: str) -> None:
@@ -253,10 +327,13 @@ def test_declarations_inventory(repo):
 def test_run_a13_end_to_end_on_tmp_repo(repo):
     r, since = repo
     _commit(r, "docs/protected.md", "v2\n", "docs: 無承認変更")
-    result = a13.run_a13(r, since_commit=since)
+    result = a13.run_a13(r, since_commit=since, pr_since_commit=since)
     assert len(result["violations"]) == 1
     assert result["mismatches"] != []  # 80-ips.md 等が無い一時リポジトリでは不整合になる
     assert len(result["declarations"]) == 2
+    # 上の無承認変更は直 push でもあるので A-13-4 でも検出される。
+    assert len(result["direct_pushes"]) == 1
+    assert result["checked_first_parent"] == 1
     # 監査部門コードのパス未登録の注記(governance.yaml のコメントで予告された検査)。
     assert any("src/ryza/audit" in n for n in result["notes"])
     assert a13.has_findings(result)
@@ -265,7 +342,7 @@ def test_run_a13_end_to_end_on_tmp_repo(repo):
 def test_standard_disclosures_always_in_notes(repo):
     """既知の限界(PR 件名未照合・トレーラ実在未照合・evil merge 検査方式)は毎回開示される。"""
     r, since = repo
-    result = a13.run_a13(r, since_commit=since)
+    result = a13.run_a13(r, since_commit=since, pr_since_commit=since)
     for disclosure in a13.STANDARD_DISCLOSURES:
         assert disclosure in result["notes"]
     # 開示は embed の注記フィールドにも常に載る。
@@ -281,18 +358,18 @@ def test_stale_checkout_warning(repo):
     newer = _commit(r, "README.md", "newer\n", "docs: newer")
     _git(r, "checkout", "-q", "main")
     _git(r, "update-ref", "refs/remotes/origin/main", newer)
-    result = a13.run_a13(r, since_commit=since)
+    result = a13.run_a13(r, since_commit=since, pr_since_commit=since)
     assert any("stale checkout" in n for n in result["notes"])
     # origin/main が HEAD の祖先なら警告しない。
     _git(r, "update-ref", "refs/remotes/origin/main", since)
-    result2 = a13.run_a13(r, since_commit=since)
+    result2 = a13.run_a13(r, since_commit=since, pr_since_commit=since)
     assert not any("stale checkout" in n for n in result2["notes"])
 
 
 # ────────────────────────────────────────────────────────────────────────────
 # embed・outbox 投入(テスト専用 DB)
 # ────────────────────────────────────────────────────────────────────────────
-def _result(violations: list, mismatches: list) -> dict:
+def _result(violations: list, mismatches: list, direct_pushes: list | None = None) -> dict:
     return {
         "as_of": "2026-08-03T00:00:00+00:00",
         "since_commit": a13.RATIFICATION_COMMIT,
@@ -300,6 +377,9 @@ def _result(violations: list, mismatches: list) -> dict:
         "violations": violations,
         "mismatches": mismatches,
         "declarations": [{"rule": "宣言その1", "verification": "棚卸し"}],
+        "pr_since_commit": a13.PR_RULE_BASELINE_COMMIT,
+        "checked_first_parent": 3,
+        "direct_pushes": direct_pushes or [],
         "notes": [],
     }
 
@@ -314,6 +394,18 @@ def test_embed_alert_on_violation():
 def test_embed_clean_when_no_findings():
     embed = a13.build_alert_embed(_result([], []))
     assert "所見なし" in embed["title"]
+    assert any(f["name"] == "A-13-4 全変更 PR 化" for f in embed["fields"])
+
+
+def test_embed_alert_on_direct_push_only():
+    """直 push のみでも要対応(has_findings)になり、A-13-4 節に載る。"""
+    d = {"commit": "beef00beef00", "subject": "s", "files": ["README.md"], "reason": "r"}
+    result = _result([], [], [d])
+    assert a13.has_findings(result)
+    embed = a13.build_alert_embed(result)
+    assert "要対応" in embed["title"]
+    field = next(f for f in embed["fields"] if "A-13-4" in f["name"] and "⚠️" in f["name"])
+    assert "beef00beef00" in field["value"]
 
 
 def test_enqueue_alert_writes_ops_outbox(conn, run_id):
@@ -328,3 +420,12 @@ def test_enqueue_alert_writes_ops_outbox(conn, run_id):
     assert channel == "ops"
     assert urgent is True  # 保護領域違反は urgent
     assert "A-13" in title
+
+
+def test_enqueue_alert_direct_push_is_urgent(conn, run_id):
+    d = {"commit": "beef00beef00", "subject": "s", "files": ["README.md"], "reason": "r"}
+    oid = a13.enqueue_alert(conn, _result([], [], [d]), run_id)
+    with conn.cursor() as cur:
+        cur.execute("SELECT urgent FROM press.outbox WHERE id = %s", (oid,))
+        (urgent,) = cur.fetchone()
+    assert urgent is True  # 直 push も統制違反として urgent

--- a/tests/audit/test_a13.py
+++ b/tests/audit/test_a13.py
@@ -3,7 +3,7 @@
 一時 git リポジトリを作り、保護領域突合(A-13-1)を承認あり/なし/PR マージ/発効日前の
 4 象限で検証する。バージョン整合(A-13-2)・宣言棚卸し(A-13-3)はフィクスチャファイルで、
 outbox 投入はテスト専用 DB で検証する。全変更 PR 化(A-13-4)は PR マージのみ/直 push/
-基準以前の3象限+例外なし(Approved トレーラ付き直 push も違反)を検証する。
+非 PR マージ/基準以前の4象限+例外なし(Approved トレーラ付き直 push も違反)を検証する。
 
 一時リポジトリでは実リポジトリの基準コミット(``PR_RULE_BASELINE_COMMIT``)が存在しない
 ため、``run_a13`` には ``pr_since_commit`` を明示的に渡す。
@@ -248,6 +248,20 @@ def test_a134_approved_trailer_is_still_violation(repo):
     )
     violations, _ = a13.check_direct_pushes(r, since_commit=since)
     assert len(violations) == 1
+
+
+def test_a134_non_pr_merge_is_violation(repo):
+    """親数>1 でも件名が PR マージ形式でないマージは違反(A-13-1 と同じ件名検査を併用)。"""
+    r, since = repo
+    _git(r, "checkout", "-q", "-b", "f1")
+    _commit(r, "README.md", "a\n", "feat: ブランチ作業")
+    _git(r, "checkout", "-q", "main")
+    _git(r, "merge", "--no-ff", "-q", "f1", "-m", "ローカルマージ(PR でない)")
+    violations, checked = a13.check_direct_pushes(r, since_commit=since)
+    assert checked == 1
+    assert len(violations) == 1
+    assert "非 PR マージ" in violations[0]["reason"]
+    assert violations[0]["files"] == ["README.md"]  # マージが main に持ち込んだ first-parent 差分
 
 
 def test_a134_pre_baseline_commits_are_excluded(repo):


### PR DESCRIPTION
## みなし承認(v0.4: 通知と同時発効)

監査部門コードへの追加。#承認 に通知済み。

- A-13-4: 基準コミット(4c7f6e9 = ルール採用日 main HEAD)以降の直 push と非 PR マージを検出(例外なし — Approved トレーラ付きでも違反)。ブランチ保護の二重底
- 独立役員審査: 条件付き承認 → 2条件反映済み(governance.yaml 変更を L1 バッチへ分離・件名検査の併用)
- governance.yaml の controls 追加行は別途 L1 PR(代表マージ)で起票する

🤖 Generated with [Claude Code](https://claude.com/claude-code)