### PR TITLE
fix(migrations): governance.decisions に 'deemed' を追加+3専決の偽装防止(0019)

### DIFF
--- a/docs/reviews/0019-decisions-deemed-independent-review.md
+++ b/docs/reviews/0019-decisions-deemed-independent-review.md
@@ -1,0 +1,23 @@
+# 独立役員意見書 — 0019_decisions_deemed(c5c361b)
+
+- 日付: 2026-08-03 / 対象: migrations/0019_decisions_deemed.sql + tests/governance/test_governance_schema.py(2 files, +88)
+- 審査者: 独立役員(非執行・批判専任。起草者の選好は不知)
+- 根拠: 定款 v0.4 第3条・第5条、config/governance.yaml(deemed_approval・protected_areas)、migrations/0007・0012、src/ryza/db/migrate.py、src/ryza/bot/approvals.py、src/ryza/audit/a13.py
+- 検証: トランザクション性・制約名・既存行互換・CI での DB テスト実行を確認(いずれも問題なし。IF EXISTS 不使用は正しい)
+
+## 判定: 条件付き承認
+
+- **C-2(重大・マージ前必須)**: `kind` と `decision` が独立で `(kind='budget'|'breaker_resume', decision='deemed')` を阻む統制がスキーマにもコードにも無い。3専決(定款第3条)の承認証跡を偽装できる。是正: `CHECK (decision <> 'deemed' OR kind NOT IN ('breaker_resume','budget'))` + 定款改廃分の kind 追加か不変条件テスト、およびテスト。
+- **C-1(重大・後続 PR 条件)**: 0007 の `UNIQUE(proposal_ref)` により deemed 発効後の事後否認が記録できない(起草者指摘に同意)。結果として deemed_ratio 形骸化アラートが構造的に発火不能、UPDATE 回避策は `Approved:` トレーラの意味を遡及改変する。是正: `governance.decision_vetoes` 追記テーブル(revert_commit・派生効果参照を含む)。**`'deemed'` の writer 実装より前**にマージすること。
+- **C-3〜C-7(中〜低)**: writer 不在で第3条の記録要件は未充足(後続タスク登録が条件) / テストの `decided_by='representative'` は deemed の定義と矛盾(`'system:deemed'` へ) / COMMENT が記録不能な「事後否認可」を主張 / 本コミットに `Approved:` トレーラ無し(migrations は保護領域) / `decisions.kind` のカタログコメントが 0012 以来 stale。
+
+## 設計リード裁定(2026-08-03 追記)
+
+- C-2: CHECK は `decision <> 'deemed' OR kind NOT IN ('breaker_resume','budget','constitution')` とする
+  (kind='constitution' は現語彙に無いが、将来追加時に穴が開かないよう先回りで列挙。無害)。
+  加えて3専決ルールの不変条件テストを tests/governance に追加。
+- C-4: 採用 — テストは `decided_by='system:deemed'`、CHECK `(decision <> 'deemed' OR decided_by LIKE 'system:%')` を追加。
+- C-5・C-7: COMMENT を実態に合わせ修正(事後否認の記録は decision_vetoes 実装まで不可の旨を明記)。
+- C-6: Approved トレーラはマージコミットに付与(既存 PR 運用と同一)。
+- C-1・C-3: ops/reminders.yaml に登録。decision_vetoes スキーマは deemed writer 実装 PR より前にマージする
+  順序制約を リマインダー本文に明記。

--- a/migrations/0019_decisions_deemed.sql
+++ b/migrations/0019_decisions_deemed.sql
@@ -1,0 +1,34 @@
+-- 0019: governance.decisions.decision に 'deemed'(みなし承認)を追加
+--
+-- 根拠: 定款 v0.4 第3条(docs/design/06-constitution.md L31)
+--   「みなし承認も `governance.decisions` に『deemed』として記録し、監査対象と
+--     する(明示承認と区別する)」
+-- 機械可読版は config/governance.yaml の deemed_approval(version 0.4):
+--   「governance.decisions に decision='deemed' で記録し、明示承認と区別する」
+--
+-- 0007 の CHECK は decision IN ('approve','reject','question') で 'deemed' を
+-- 許容しないため、定款どおりの記録が INSERT できない(定款と実装の乖離)。
+-- 監査 A-13(無承認変更検出)は承認トレーラ `Approved:` が指す decisions 行と
+-- 突合するため、みなし承認が記録できないことは統制の穴になる。
+--
+-- 'approve'(代表の明示承認 — 第3条の3専決事項)と 'deemed'(通知即発効の
+-- みなし承認)を別の語彙に保つのは意図的である。監査部門が追う deemed_ratio
+-- (形骸化アラート)は両者を区別できて初めて計算できる。
+--
+-- 既存行への影響: 語彙の拡大のみ(既存の3値は全て新 CHECK でも真)。
+-- 0012 が kind に対して行った拡大と同じ流儀。
+--
+-- 旧: CHECK (decision IN ('approve', 'reject', 'question'))
+-- 新: CHECK (decision IN ('approve', 'reject', 'question', 'deemed'))
+
+ALTER TABLE governance.decisions DROP CONSTRAINT decisions_decision_check;
+ALTER TABLE governance.decisions ADD CONSTRAINT decisions_decision_check
+    CHECK (decision IN ('approve', 'reject', 'question', 'deemed'));
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- データカタログ用コメント(0007 の記述を更新)
+-- ────────────────────────────────────────────────────────────────────────────
+COMMENT ON COLUMN governance.decisions.decision IS
+    'approve|reject|question|deemed。approve=代表の明示承認(定款第3条の3専決事項)、'
+    'deemed=みなし承認(#承認 への通知と同時に発効・事後否認可 — 定款 v0.4 第3条)。'
+    '両者を区別することで監査部門が deemed_ratio(形骸化アラート)を計算できる。';

--- a/migrations/0019_decisions_deemed.sql
+++ b/migrations/0019_decisions_deemed.sql
@@ -26,9 +26,46 @@ ALTER TABLE governance.decisions ADD CONSTRAINT decisions_decision_check
     CHECK (decision IN ('approve', 'reject', 'question', 'deemed'));
 
 -- ────────────────────────────────────────────────────────────────────────────
--- データカタログ用コメント(0007 の記述を更新)
+-- 3専決事項への 'deemed' 適用を禁止(独立役員審査 C-2・設計リード裁定 2026-08-03)
+-- ────────────────────────────────────────────────────────────────────────────
+-- 定款第3条の representative_reserved(config/governance.yaml)— 定款改正・実弾
+-- マネー・Kill Switch 復帰 — は代表の明示承認が必須であり、みなし承認では発効
+-- しない。0007 の kind と decision は互いに独立なため、この制約が無いと
+-- (kind='budget', decision='deemed') のような行が書けてしまい、3専決事項の
+-- 承認証跡を偽装できる(A-13 の `Approved:` 突合は decisions 行を真とする)。
+--
+-- kind の対応: live_money → 'budget'、kill_switch_resume → 'breaker_resume'、
+-- constitution_amendment → 'constitution'(現 kind 語彙には未登録。将来追加時に
+-- 穴が開かないよう先回りで列挙する。未登録の値を列挙しても既存行には無害)。
+ALTER TABLE governance.decisions ADD CONSTRAINT decisions_deemed_not_reserved_check
+    CHECK (decision <> 'deemed'
+           OR kind NOT IN ('breaker_resume', 'budget', 'constitution'));
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 'deemed' の decided_by はシステム主体に限る(独立役員審査 C-4)
+-- ────────────────────────────────────────────────────────────────────────────
+-- みなし承認は「代表が押した」記録ではなく「通知により自動発効した」記録である。
+-- decided_by に代表の Discord ユーザー ID を書くと、明示承認との区別が
+-- decision 列だけに依存し、証跡としては代表の作為に見えてしまう。
+-- 0012 の killswitch_events.actor が使う 'system:<source>' 表記に合わせる。
+ALTER TABLE governance.decisions ADD CONSTRAINT decisions_deemed_system_actor_check
+    CHECK (decision <> 'deemed' OR decided_by LIKE 'system:%');
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- データカタログ用コメント(0007・0012 の記述を実態に合わせて更新)
 -- ────────────────────────────────────────────────────────────────────────────
 COMMENT ON COLUMN governance.decisions.decision IS
     'approve|reject|question|deemed。approve=代表の明示承認(定款第3条の3専決事項)、'
-    'deemed=みなし承認(#承認 への通知と同時に発効・事後否認可 — 定款 v0.4 第3条)。'
-    '両者を区別することで監査部門が deemed_ratio(形骸化アラート)を計算できる。';
+    'deemed=みなし承認(#承認 への通知と同時に発効 — 定款 v0.4 第3条。decided_by は '
+    'system:<source>、3専決の kind には付けられない)。両者を区別することで監査部門が '
+    'deemed_ratio(形骸化アラート)を計算できる。'
+    '注意: 定款が定める事後否認は本テーブルには記録できない — proposal_ref の UNIQUE で '
+    '1提案=1行に固定されており、追記オンリーの否認記録テーブル '
+    '(governance.decision_vetoes・未実装)の導入までは否認の証跡を残す場所が無い。';
+
+-- 0012 で 'frozen_exception_trade' を追加した際にカタログコメントが更新されず
+-- stale になっていた(独立役員審査 C-7)。
+COMMENT ON COLUMN governance.decisions.kind IS
+    'pr|strategy_promotion|breaker_resume|budget|frozen_exception_trade|other。'
+    'breaker_resume・budget は定款第3条の3専決事項に対応し、decision=''deemed'' を'
+    '付けられない(decisions_deemed_not_reserved_check)。';

--- a/ops/reminders.yaml
+++ b/ops/reminders.yaml
@@ -298,6 +298,30 @@ reminders:
       body: "独立役員 再審査 2026-08-03(docs/reviews/dashboard-deploy-independent-review.md 再審査記録「次回 PR 対応」)。条件付き承認のマージ阻止要因ではないが、着手期限を切って残す。(1) ロール検証クエリのゲート化: ops/deploy-dashboard.sh のロール定義 SQL 末尾にある dashboard_write_grants などの検証クエリは現在ログ出力のみで、値が想定外でもデプロイが続行する。DO ブロックで例外を上げるか結果を読んで中断する。(2) pg_hba 検査の CIDR 列限定: 現在は行全体の文字列マッチのため、コメントやデータベース名に localhost を含む行を誤って安全と判定しうる。アドレス列を取り出して判定する。(3) デプロイ統制のリグレッションテスト: git ゲート(dirty・HEAD != origin/main・origin URL 不一致)と公開バインディング検査が『実際に中断する』ことを検証するテストが無い。統制コードは壊れても静かに通るため、**Phase 5 の Cloud Build トリガー化(dashboard-cloudbuild-trigger)に着手する前に必須**とする。"
     status: pending
 
+  - id: governance-decision-vetoes-schema
+    what: "みなし承認の事後否認を記録する追記オンリーテーブル governance.decision_vetoes(定款 v0.4 第3条が定める否認権の証跡。独立役員審査 0019 C-1)"
+    conditions:
+      - type: date_after
+        date: "2026-08-17"
+    action:
+      type: issue_create
+      title: "governance.decision_vetoes(みなし承認の事後否認記録)を追加する"
+      labels: [impl]
+      body: "定款 v0.4 第3条は『みなし承認は通知と同時に発効し、代表はいつでも否認できる。否認された変更は遅滞なく取り消し、派生効果を #運営 へ報告する』と定めるが、この否認を記録する場所がスキーマに無い(独立役員審査 0019 C-1)。governance.decisions は 0007 の UNIQUE(proposal_ref) で 1提案=1行に固定されているため、否認を新規行として INSERT できず、既存行を UPDATE すると `Approved:` トレーラが指す承認記録の意味を遡及的に改変してしまう(A-13 の突合が過去に遡って壊れる)。結果として、監査部門が追う deemed_ratio(否認ゼロの長期継続=形骸化アラート)は構造的に発火不能な状態にある。是正: governance.decisions を参照する追記オンリーの governance.decision_vetoes テーブル(decision_id への FK・否認者・否認理由・取消コミット revert_commit・取消不能な派生効果の参照・run_id、UPDATE/DELETE 禁止トリガは 0013 の minutes/stances と同型)を migrations で追加し、A-13 と deemed_ratio 集計がこれを読む配線を行う。**順序制約: 本テーブルは governance-deemed-writer(みなし承認の記録 writer)の実装 PR より前にマージすること** — writer が先に入ると、否認できない deemed 行が本番データとして積み上がり、後から否認証跡を遡及付与できない。migrations は保護領域のため独立役員審査+みなし承認の手続を経ること。"
+    status: pending
+
+  - id: governance-deemed-writer
+    what: "みなし承認を governance.decisions に decision='deemed' で記録する writer の実装(0019 でスキーマは通ったが書き手が居ない。独立役員審査 0019 C-3)"
+    conditions:
+      - type: date_after
+        date: "2026-08-24"
+    action:
+      type: issue_create
+      title: "みなし承認の記録 writer(decision='deemed')を実装する"
+      labels: [impl]
+      body: "0019 で governance.decisions.decision に 'deemed' を許容したが、実際にその行を書くコードが無いため、定款 v0.4 第3条3号の記録要件(『みなし承認も governance.decisions に deemed として記録し、監査対象とする』)は未充足のままである(独立役員審査 0019 C-3)。実装内容: ①#承認 への PR リンク付き通知(src/ryza/bot/approvals.py 経路)と同一トランザクションで deemed 行を INSERT する、②decided_by は 'system:<source>' 形式(0019 の decisions_deemed_system_actor_check)、③3専決事項の kind には付けない(decisions_deemed_not_reserved_check がスキーマ側で拒否する — アプリ側でも事前に弾いて分かりやすいエラーにする)、④proposal_ref は PR URL 等の一意参照とし二重記録を UNIQUE で防ぐ、⑤A-13-1 の `Approved:` トレーラ突合が deemed 行を承認記録として受理することを確認。**順序制約: governance-decision-vetoes-schema(否認記録テーブル)のマージ後に着手すること** — 否認を記録できない状態で deemed 行を量産すると、代表が否認権を行使しても証跡を残せない。"
+    status: pending
+
   - id: db-role-separation-webhook-url
     what: "DB ロール分離: ops.discord_webhooks(webhook URL)の読取を配送コンポーネント専用ロールへ限定(実弾移行前提)"
     conditions:

--- a/tests/governance/test_governance_schema.py
+++ b/tests/governance/test_governance_schema.py
@@ -6,8 +6,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import psycopg
 import pytest
+import yaml
 
 from ryza.db.conn import connect
 from ryza.governance.personas import assume_role, recent_stances, record_stance
@@ -241,15 +244,34 @@ def test_retraction_requires_target_and_same_role(conn, run_id):
 
 
 # ── decisions の決定語彙(0019・定款 v0.4 第3条)──────────────────────────
-def _new_decision(cur, proposal_ref: str, decision: str, kind: str = "pr") -> int:
+# 定款第3条の3専決事項(config/governance.yaml の representative_reserved)と
+# decisions.kind の対応。**governance.yaml に専決事項を足したらここも足す** —
+# test_reserved_matters_cover_governance_yaml が漏れを検出する。
+RESERVED_KIND_BY_MATTER = {
+    "constitution_amendment": "constitution",  # 現 kind 語彙には未登録(0019 で先回り列挙)
+    "live_money": "budget",
+    "kill_switch_resume": "breaker_resume",
+}
+
+
+def _new_decision(
+    cur,
+    proposal_ref: str,
+    decision: str,
+    kind: str = "pr",
+    decided_by: str | None = None,
+) -> int:
+    # みなし承認は代表の作為ではなく通知による自動発効(0019 C-4 の CHECK)。
+    if decided_by is None:
+        decided_by = "system:deemed" if decision == "deemed" else "representative"
     cur.execute(
         """
         INSERT INTO governance.decisions
             (proposal_ref, kind, decision, decided_by, note)
-        VALUES (%s, %s, %s, 'representative', 'test')
+        VALUES (%s, %s, %s, %s, 'test')
         RETURNING id
         """,
-        (proposal_ref, kind, decision),
+        (proposal_ref, kind, decision, decided_by),
     )
     return cur.fetchone()[0]
 
@@ -290,6 +312,86 @@ def test_unknown_decision_rejected(conn):
     with conn.cursor() as cur:
         with pytest.raises(psycopg.errors.CheckViolation):
             _new_decision(cur, "rubber-stamp-2026-08", "deemed_approved")
+    conn.rollback()
+
+
+# ── 3専決事項は「みなし」で発効させられない(独立役員審査 C-2)──────────────
+@pytest.mark.parametrize("kind", sorted(set(RESERVED_KIND_BY_MATTER.values())))
+def test_reserved_matter_cannot_be_deemed(conn, kind):
+    """3専決(定款第3条)の kind に decision='deemed' は付けられない。
+
+    kind と decision は互いに独立な列なので、この CHECK が無いと
+    (kind='budget', decision='deemed') で実弾投入の承認証跡を偽装できる。
+    """
+    with conn.cursor() as cur:
+        with pytest.raises(psycopg.errors.CheckViolation):
+            _new_decision(cur, f"forged-{kind}", "deemed", kind=kind)
+    conn.rollback()
+
+
+@pytest.mark.parametrize("kind", sorted(set(RESERVED_KIND_BY_MATTER.values())))
+def test_reserved_matter_accepts_explicit_approval(conn, kind):
+    """禁止されるのは 'deemed' だけ — 明示承認の経路は塞がない。
+
+    'constitution' は 0019 が先回りで列挙した未登録 kind なので、
+    decisions_kind_check(0012)の側で弾かれることを期待値として固定する。
+    """
+    expected_ok = kind != "constitution"
+    with conn.cursor() as cur:
+        if expected_ok:
+            assert _new_decision(cur, f"explicit-{kind}", "approve", kind=kind) > 0
+        else:
+            with pytest.raises(psycopg.errors.CheckViolation):
+                _new_decision(cur, f"explicit-{kind}", "approve", kind=kind)
+    conn.rollback()
+
+
+def test_reserved_matters_cover_governance_yaml(conn):
+    """不変条件: governance.yaml の全専決事項が 'deemed' 不可の kind に対応する。
+
+    定款第3条の representative_reserved に4つ目が足された(= 委任範囲が縮んだ)のに
+    スキーマ側の禁止リストが据え置かれる、という乖離を検出する。
+    """
+    root = Path(__file__).resolve().parents[2]
+    gov = yaml.safe_load((root / "config" / "governance.yaml").read_text("utf-8"))
+    reserved = set(gov["representative_reserved"])
+    assert reserved == set(RESERVED_KIND_BY_MATTER), (
+        "governance.yaml の専決事項と RESERVED_KIND_BY_MATTER が乖離している。"
+        "対応する kind を決め、0019 の decisions_deemed_not_reserved_check にも足すこと。"
+    )
+    # 対応表の kind が実際に DB 側で禁止されていることまで確認する(宣言で終わらせない)。
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_get_constraintdef(oid) FROM pg_constraint
+            WHERE conrelid = 'governance.decisions'::regclass
+              AND conname = 'decisions_deemed_not_reserved_check'
+            """
+        )
+        row = cur.fetchone()
+    assert row is not None, "decisions_deemed_not_reserved_check が存在しない"
+    for matter, kind in RESERVED_KIND_BY_MATTER.items():
+        assert f"'{kind}'" in row[0], f"{matter} の kind={kind} が CHECK に無い"
+
+
+# ── deemed の実行主体はシステム(独立役員審査 C-4)────────────────────────
+def test_deemed_by_representative_rejected(conn):
+    """みなし承認は代表の作為ではない — decided_by は 'system:%' に限る。"""
+    with conn.cursor() as cur:
+        with pytest.raises(psycopg.errors.CheckViolation):
+            _new_decision(
+                cur, "deemed-by-rep", "deemed", decided_by="representative"
+            )
+    conn.rollback()
+
+
+def test_explicit_approval_by_representative_still_allowed(conn):
+    """明示承認側に 'system:%' 制約は掛からない(C-4 の CHECK は deemed 限定)。"""
+    with conn.cursor() as cur:
+        assert (
+            _new_decision(cur, "explicit-by-rep", "approve", decided_by="representative")
+            > 0
+        )
     conn.rollback()
 
 

--- a/tests/governance/test_governance_schema.py
+++ b/tests/governance/test_governance_schema.py
@@ -1,4 +1,4 @@
-"""0013_governance_assets.sql とローダの DB 依存部分の受け入れテスト。
+"""0013_governance_assets.sql / 0019_decisions_deemed.sql とローダの DB 依存部分の受け入れテスト。
 
 テスト専用 DB(tests/conftest.py の ``migrated_db``)に対して実行する。
 接続不可なら skip(Docker 未導入環境向け)。テストは commit せず rollback で隔離。
@@ -237,6 +237,59 @@ def test_retraction_requires_target_and_same_role(conn, run_id):
             conn, role="independent_officer", kind="retraction",
             summary="越権撤回", run_id=run2, retracts=sid,
         )
+    conn.rollback()
+
+
+# ── decisions の決定語彙(0019・定款 v0.4 第3条)──────────────────────────
+def _new_decision(cur, proposal_ref: str, decision: str, kind: str = "pr") -> int:
+    cur.execute(
+        """
+        INSERT INTO governance.decisions
+            (proposal_ref, kind, decision, decided_by, note)
+        VALUES (%s, %s, %s, 'representative', 'test')
+        RETURNING id
+        """,
+        (proposal_ref, kind, decision),
+    )
+    return cur.fetchone()[0]
+
+
+def test_deemed_decision_accepted(conn):
+    """みなし承認は decision='deemed' で記録できる(定款 v0.4 第3条)。"""
+    with conn.cursor() as cur:
+        assert _new_decision(cur, "ips-rev-2026-08-deemed", "deemed") > 0
+    conn.rollback()
+
+
+def test_explicit_and_deemed_are_distinct(conn):
+    """明示承認と区別して残る — 監査の deemed_ratio 計算の前提(定款第3条)。"""
+    with conn.cursor() as cur:
+        _new_decision(cur, "live-money-2026-08", "approve", kind="budget")
+        _new_decision(cur, "mandate-rev-2026-08", "deemed")
+        cur.execute(
+            """
+            SELECT decision FROM governance.decisions
+            WHERE proposal_ref IN ('live-money-2026-08', 'mandate-rev-2026-08')
+            ORDER BY proposal_ref
+            """
+        )
+        assert [r[0] for r in cur.fetchall()] == ["approve", "deemed"]
+    conn.rollback()
+
+
+def test_legacy_decisions_still_accepted(conn):
+    """0007 の既存語彙は壊れない(0019 は語彙の拡大のみ)。"""
+    with conn.cursor() as cur:
+        for i, decision in enumerate(("approve", "reject", "question")):
+            assert _new_decision(cur, f"legacy-{i}", decision) > 0
+    conn.rollback()
+
+
+def test_unknown_decision_rejected(conn):
+    """語彙外の決定は CHECK で拒否される(承認記録の語彙を固定する)。"""
+    with conn.cursor() as cur:
+        with pytest.raises(psycopg.errors.CheckViolation):
+            _new_decision(cur, "rubber-stamp-2026-08", "deemed_approved")
     conn.rollback()
 
 


### PR DESCRIPTION
## 概要

定款 v0.4 第3条の「みなし承認」記録(`decision='deemed'`)を governance.decisions の CHECK が許容していなかった問題の修正+独立審査で発見された偽装経路の封鎖。

- `decisions_decision_check` に 'deemed' を追加(語彙拡大のみ・既存行互換)
- **`decisions_deemed_not_reserved_check`**: 3専決(breaker_resume/budget/constitution)を deemed で通す承認証跡の偽装をスキーマで拒否(審査 C-2)
- **`decisions_deemed_system_actor_check`**: deemed 行の decided_by は `system:%` に限定(代表が決定していないことを記録面で保証 — 審査 C-4)
- 不変条件テスト: governance.yaml の representative_reserved と CHECK 定義の集合一致を検査(専決が増えたら落ちる)
- COMMENT 修正: 「事後否認可」の過大主張を削除(否認記録は decision_vetoes 実装まで不可)・kind の stale 補完
- 後続2件を ops/reminders.yaml に登録(decision_vetoes スキーマ → deemed writer の順序制約明記)

## 承認・審査

- 保護領域該当: migrations(schema)。独立役員審査: 条件付き承認 → 必須条件(C-2/C-5/C-7)+推奨(C-4)を実装済み。意見書: docs/reviews/0019-decisions-deemed-independent-review.md
- みなし承認(定款第3条 v0.4): #承認 通知と同時発効・代表はいつでも否認可

## 検証

852 テスト+ruff 通過(governance スキーマテスト 27 件・新規9件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)