### PR TITLE
feat(org): キャラクターアイコンのダッシュボード再設定(0020)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -476,9 +476,83 @@ def _member_card_html(m: dict[str, Any]) -> str:
     )
 
 
-def page_org() -> None:
+def _icon_editor(members: list[dict[str, Any]], overrides: dict[str, str]) -> None:
+    """アイコン編集 UI(代表指示 2026-08-03)。上書きは ``ops.org_icon_overrides``(0020)。
+
+    **認可**: 追加の認証は置かない。このダッシュボードは IAP の許可リスト
+    (roles/iap.httpsResourceAccessor)で**代表1名**に限定されており、到達できる時点で
+    代表であることが保証される(役員室の追記 UI と同じ根拠 — app.py 冒頭・
+    ops/deploy-dashboard.sh)。したがって ``updated_by`` は固定で 'representative'。
+    書込は読取接続ではなく役員室と同じ最小権限ロール ``ryza_boardroom``
+    (``queries.connect_boardroom``)で行う。
+    """
+    st.subheader("アイコンの変更(代表のみ・DB 上書き)")
+    st.caption(
+        "台帳(config/org.yaml)の値を DB 側で上書きする(0020)。保存すると Discord の"
+        "投稿(webhook の avatar)にも次の配送から反映される。「初期値に戻す」で上書きを"
+        "削除すると台帳の値へ戻る。"
+    )
+    for m in members:
+        member_id = str(m.get("id", ""))
+        label = f"{m.get('name', '')}({m.get('title', '')})"
+        overridden = member_id in overrides
+        with st.expander(f"{label}{' — 上書き中' if overridden else ''}"):
+            current = overrides.get(member_id) or m.get("icon_url") or ""
+            cols = st.columns([1, 3])
+            with cols[0]:
+                if current:
+                    st.image(current, width=96)
+                else:
+                    st.caption("(アイコン未設定)")
+            with cols[1]:
+                with st.form(f"icon_form_{member_id}"):
+                    url = st.text_input(
+                        "画像 URL(https の直リンク)", value=current, key=f"icon_url_{member_id}"
+                    )
+                    save = st.form_submit_button("保存")
+                    reset = st.form_submit_button("初期値に戻す", disabled=not overridden)
+                if save or reset:
+                    _apply_icon_change(member_id, url, save=bool(save))
+
+
+def _apply_icon_change(member_id: str, url: str, *, save: bool) -> None:
+    """保存/リセットを実行し、結果を表示して再描画する(失敗時は保存しない)。"""
+    try:
+        wconn = queries.connect_boardroom()
+    except Exception as exc:  # noqa: BLE001 - DB 停止時も UI は説明を出して生かす
+        st.error(f"DB に接続できない: {exc}")
+        return
+    try:
+        if save:
+            org.update_icon(wconn, member_id, url, "representative")
+            st.success("アイコンを更新した")
+        elif org.clear_icon_override(wconn, member_id, "representative"):
+            st.success("上書きを削除し台帳の初期値へ戻した")
+        else:
+            st.info("上書きは無い(既に台帳の初期値)")
+    except org.IconUrlError as exc:
+        st.error(f"保存しなかった(URL 検証に失敗): {exc}")
+        return
+    except KeyError as exc:
+        st.error(f"保存しなかった: {exc}")
+        return
+    except Exception as exc:  # noqa: BLE001 - 権限不足等も画面に出す(黙って失敗しない)
+        st.error(f"保存に失敗: {exc}")
+        return
+    st.rerun()  # プレビュー・カードを即時更新する
+
+
+def page_org(conn=None) -> None:
     st.header("組織")
-    org = queries.load_org()
+    org_yaml = queries.load_org()
+    # アイコンの DB 上書き(0020)を台帳より優先。DB に繋がらない場合も台帳だけで表示を続ける。
+    overrides: dict[str, str] = {}
+    db_error: str | None = None
+    if conn is not None:
+        try:
+            overrides = org.icon_overrides(conn)
+        except Exception as exc:  # noqa: BLE001 - 表示は台帳へフォールバック
+            db_error = str(exc)
 
     st.subheader("組織図(00-system-design §3・14部門+開発部門)")
     st.markdown(_org_chart_html(), unsafe_allow_html=True)
@@ -487,8 +561,8 @@ def page_org() -> None:
         "投資委員会へ直接報告する。"
     )
 
-    st.subheader("メンバー(config/org.yaml が正)")
-    rep = org.get("representative", {})
+    st.subheader("メンバー(config/org.yaml が正・アイコンは DB 上書きを優先)")
+    rep = org_yaml.get("representative", {})
     rep_card = (
         "<div class='oc-card' style='--mc:#64748b'>"
         "<div class='oc-avatar oc-fallback' style='background:#64748b'>代</div>"
@@ -497,12 +571,23 @@ def page_org() -> None:
         "<div><span class='oc-chip'>人間</span>"
         "<span class='oc-chip'>投資委員会</span></div></div></div>"
     )
-    cards = rep_card + "".join(_member_card_html(m) for m in org.get("members", []))
+    members = [dict(m) for m in org_yaml.get("members", [])]
+    for m in members:
+        override = overrides.get(str(m.get("id", "")))
+        if override:
+            m["icon_url"] = override
+    cards = rep_card + "".join(_member_card_html(m) for m in members)
     st.markdown(_ORG_CSS + f"<div class='oc-members'>{cards}</div>", unsafe_allow_html=True)
     st.caption(
         "モデル階層は「まず非LLM → 軽量 → 中位 → Fable」の原則(CLAUDE.md)。"
-        "アイコン未設定のメンバーはカラーの頭文字で代替表示(icon_url 設定タスクは別途)。"
+        "アイコン未設定のメンバーはカラーの頭文字で代替表示。"
     )
+    if db_error is not None:
+        st.warning(f"アイコン上書き(DB)を読めなかったため台帳の値で表示している: {db_error}")
+    if conn is None:
+        st.info("DB に接続できないため、アイコンの変更 UI は表示していない(表示は台帳の値)。")
+        return
+    _icon_editor(members, overrides)
 
 
 # ── 承認・通知(組織サイト化)──────────────────────────────────────────────────
@@ -1063,7 +1148,13 @@ def main() -> None:
         page_boardroom()  # 書込可の専用接続を自前で持つ(READ ONLY 接続は使わない)
         return
     if page == "組織":
-        page_org()  # config/org.yaml のみ(DB 不要)
+        # 台帳(config/org.yaml)が主。アイコンの上書き(0020)の読取にだけ DB を使うため、
+        # 接続できなくても台帳だけでページを出す(編集 UI は隠す)。
+        try:
+            org_conn = _conn()
+        except Exception:  # noqa: BLE001 - DB 停止時も組織ページは表示する
+            org_conn = None
+        page_org(org_conn)
         return
     if page == "規則":
         page_rules()  # config/governance.yaml のみ(DB 不要)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -516,9 +516,14 @@ def _icon_editor(members: list[dict[str, Any]], overrides: dict[str, str]) -> No
 
 
 def _apply_icon_change(member_id: str, url: str, *, save: bool) -> None:
-    """保存/リセットを実行し、結果を表示して再描画する(失敗時は保存しない)。"""
+    """保存/リセットを実行し、結果を表示して再描画する(失敗時は保存しない)。
+
+    接続は役員室と同じ ``_boardroom_conn()``(``@st.cache_resource``)を**再利用**する
+    (独立役員審査 0020 C-9)。保存のたびに新規接続を開くと、Streamlit の再実行ごとに
+    close されない接続が積み上がる。
+    """
     try:
-        wconn = queries.connect_boardroom()
+        wconn = _boardroom_conn()
     except Exception as exc:  # noqa: BLE001 - DB 停止時も UI は説明を出して生かす
         st.error(f"DB に接続できない: {exc}")
         return

--- a/docs/reviews/0020-org-icon-overrides-independent-review.md
+++ b/docs/reviews/0020-org-icon-overrides-independent-review.md
@@ -1,0 +1,27 @@
+# 独立役員意見書 — 0020 キャラクターアイコンの上書き(ee5bac9..09d8ee4)
+
+- 日付: 2026-08-03 / 対象: migrations/0020_org_icon_overrides.sql(保護領域 schema)、ops/deploy-dashboard.sh の GRANT(deploy_path 相当)、src/ryza/org.py、src/ryza/bot/main.py、dashboard/app.py(8 files, +720/-23)
+- 審査者: 独立役員(非執行・批判専任。起草者の選好は不知)
+- 根拠: 定款第5条、config/governance.yaml(protected_areas)、migrations/0013・0017・0020、src/ryza/bot/outbox.py、dashboard/queries.py、src/ryza/audit/a13.py
+- 検証: ops スキーマに関数が無く `USAGE ON SCHEMA ops` 追加で表権限が増えないこと、BR ロールが trading_state/flags/discord_webhooks に到達しないこと、履歴表が INSERT のみであること、内部キー member_id が Discord へ出ない全経路(resolve_author・payload_for・dict_to_embed・bridge_send)を確認
+
+## 判定: 条件付き承認
+
+- **C-1(重大・マージ前必須)**: 0020:26-28 が方式 B の担保と謳う「現在値とログを同一トランザクションで書く」が本番経路で不成立。connect_boardroom は autocommit=True(queries.py:74)で org.py:274-304/327-345 に transaction ブロックが無い。テストは autocommit=False 接続(tests/ops/…:23)のため検出できない。是正: `with conn.transaction():` + autocommit 前提のテスト。
+- **C-2(重大・マージ前必須)**: main.py:303 の icon_overrides 例外が outbox.py:124-127 の無言 continue に落ち、0020 未適用や一時的 DB エラーで**全 Discord 配送が無言停止**(速報・Kill Switch 通報を含む)。是正: {} へフェイルオープン + log.warning。
+- **C-3(中)**: 履歴表の追記オンリーが GRANT のみ。0013:59-82 の forbid_mutation トリガ + REVOKE FROM PUBLIC の先例に不一致で、owner ロールが履歴を消せる。
+- **C-4(中)**: ops/deploy-dashboard.sh は protected_areas 未登録(governance.yaml:113-118 は bot/daily/ops-weekly のみ)。A-13-1 が変更を検出しない。本 PR に `Approved:` トレーラも無い(migrations は schema 領域)。
+- **C-5(中)**: 証跡セクション(:297-305)は dash ロールのみ検査。to_regclass ガードで GRANT が黙ってスキップされうる。BR ロールの ops 権限が期待2表のみであることのアサーションを追加。
+- **C-6/C-7(中)**: check_icon_url はリダイレクト自動追従・ホスト制限なし(SSRF)。ホットリンクすり替えの起草者懸念は妥当だが重大度は**中** — Discord はサーバ側取得のため閲覧者 IP は漏れず、被害は代表 IP の追跡と非公開サーバーへの意図しない画像に限る。検証は UA 識別可能な単発 HEAD で誠実な誤りしか防げない。恒久是正は保存時の再ホスト。
+- **C-8〜C-10(低)**: image/svg+xml とサイズ上限なし / 保存ごとの未 close 接続(app.py:521。既存 _boardroom_conn を使うべき)/ 内部キーが全 outbox 行に永続化され除去が送信直前の1関数に依存。
+- 妥当と認めた点: 台帳優先の層構造、未知 id の無視、検証と書込の結線、HTML エスケープ、action/icon_url 相関 CHECK、dash ロール除外リストに追加しない判断。
+
+## 設計リード裁定(2026-08-03 追記)
+
+- 今回の PR 内で是正: C-1・C-2(必須)、C-3(0013 同型トリガ+REVOKE)、C-5(BR ロールのデプロイ時アサーション)、
+  C-9(既存 _boardroom_conn の再利用)、C-6 暫定(リダイレクト無効化+解決先 private/link-local IP の拒否)、
+  C-8(MIME を png/jpeg/gif/webp に限定+Content-Length 上限 5MB)。
+- リマインダー登録して後続: C-4(protected_areas への deploy-dashboard.sh 登録 — governance.yaml 側の別 PR)、
+  C-7 恒久(保存時の再ホスト化 — 再配布の法的懸念の整理込み)、C-10(内部キーの構造分離)。
+- 反対意見書1(投入時解決+TTL キャッシュ)は不採用: C-2 のフェイルオープン化で可用性懸念は解消され、
+  配送時解決の「滞留中の投稿も新アイコンになる」利点を保つ方を選ぶ。

--- a/migrations/0020_org_icon_overrides.sql
+++ b/migrations/0020_org_icon_overrides.sql
@@ -1,0 +1,75 @@
+-- 0020: キャラクターアイコンの実行時上書き(代表指示 2026-08-03)
+--
+-- 目的: 代表が `config/org.yaml` を編集し PR を通さなくても、ダッシュボードから
+-- キャラクターのアイコンを差し替えられるようにする。台帳(org.yaml)は**引き続き正**で、
+-- 本テーブルはその上に重ねる「実行時の上書き層」である(ローダ src/ryza/org.py の
+-- effective_members が YAML → DB の順にマージする)。
+--
+-- FK を張らない理由: member_id の正は `config/org.yaml`(ファイル)であり DB に
+-- メンバー表が無い。整合はローダ側で突合し、台帳に無い member_id の上書き行は
+-- **黙って無視**する(YAML から消えたキャラの残骸が表示に混ざらない)。
+--
+-- ────────────────────────────────────────────────────────────────────────────
+-- 履歴方式の選択: 「現在値テーブル + 追記オンリーの別ログ表」(方式 B)
+-- ────────────────────────────────────────────────────────────────────────────
+-- 上書きの本義は「今どのアイコンか」を1行で引けることなので、現在値は PK=member_id の
+-- 1行に保ち UPDATE で上書きする。ただし UPDATE は履歴を消すため、変更は別の追記表
+-- (org_icon_override_log)へ必ず1行残す。
+--
+-- 検討した代替(方式 A: 履歴表だけを持ち、最新行を毎回 window 関数で引く)を採らないのは:
+--   1. 読取が全経路(Bot の配送ごと・ダッシュボードの描画ごと)で走るため、
+--      「PK 1行の SELECT」で済む形の方が単純かつ速い(即反映のため**キャッシュしない**)
+--   2. 削除(初期値に戻す)を「現在値が無い」で表現でき、状態の解釈が一意になる
+--      (方式 A では最新行が tombstone かを毎回判定する必要がある)
+--   3. ops.flags / ops.flag_events(0007)・ops.trading_state /
+--      governance.killswitch_events(0012)と同じ既存の流儀に揃う
+-- 方式 B の弱点は「現在値とログが乖離しうる」こと。書込ヘルパ
+-- (org.set_icon_override / clear_icon_override)は同一トランザクションで両方に書き、
+-- ログ側にだけ書く経路・現在値だけ書く経路をコードに作らないことで担保する。
+
+CREATE TABLE ops.org_icon_overrides (
+    member_id  text PRIMARY KEY,            -- config/org.yaml の members[].id
+    icon_url   text NOT NULL,               -- https の画像 URL(検証は org.check_icon_url)
+    updated_by text NOT NULL,               -- 'representative' 等(IAP が代表1名に限定)
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 上書きは Discord / Web の表示にそのまま出るため、https 以外を DB 層でも拒む
+-- (アプリ側 org.check_icon_url が主たる検証。ここは最後の防壁で、混入経路を塞ぐ)。
+ALTER TABLE ops.org_icon_overrides ADD CONSTRAINT org_icon_overrides_https_check
+    CHECK (icon_url LIKE 'https://%');
+
+CREATE TABLE ops.org_icon_override_log (
+    id         bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    member_id  text NOT NULL,
+    action     text NOT NULL CHECK (action IN ('set', 'reset')),
+    icon_url   text,                        -- set=新しい URL / reset=NULL(初期値へ復帰)
+    actor      text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    -- action と icon_url の対応を強制する(reset に URL が残る/set が空、を防ぐ)。
+    CONSTRAINT org_icon_override_log_action_url_check
+        CHECK ((action = 'set') = (icon_url IS NOT NULL))
+);
+CREATE INDEX org_icon_override_log_member_idx
+    ON ops.org_icon_override_log (member_id, created_at);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 権限に関する注記(0017 との違い)
+-- ────────────────────────────────────────────────────────────────────────────
+-- 0017 の ops.discord_webhooks は「URL を知る者が誰でも投稿できる」秘密のため、
+-- 読取ロール ryza_dashboard から明示的に REVOKE している。本テーブルは秘密を
+-- 持たない(公開画像の URL のみ)ので、その除外リストには**入れない** — 組織ページの
+-- 表示に必要な読取である。書込は役員室と同じ ryza_boardroom ロールに限定し、
+-- GRANT は ops/deploy-dashboard.sh のロール SQL 側で与える(保護領域 deploy_path)。
+
+COMMENT ON TABLE ops.org_icon_overrides IS
+    'キャラクターアイコンの実行時上書き(現在値)。config/org.yaml が正で、本表はその上に'
+    '重ねる層。行が無ければ台帳の icon_url を使う(0020)。';
+COMMENT ON COLUMN ops.org_icon_overrides.member_id IS
+    'config/org.yaml の members[].id。FK は張れないためローダ側で突合し、台帳に無い id は無視。';
+COMMENT ON COLUMN ops.org_icon_overrides.icon_url IS
+    'https の画像 URL。Content-Type image/* の実アクセス検証を通ったものだけを書く。';
+COMMENT ON TABLE ops.org_icon_override_log IS
+    'アイコン上書きの変更履歴(追記オンリー)。現在値表の UPDATE/DELETE で消える履歴を残す(0020)。';
+COMMENT ON COLUMN ops.org_icon_override_log.action IS
+    'set=上書き設定/更新、reset=上書き削除(台帳の初期値へ復帰)。';

--- a/migrations/0020_org_icon_overrides.sql
+++ b/migrations/0020_org_icon_overrides.sql
@@ -54,6 +54,57 @@ CREATE INDEX org_icon_override_log_member_idx
     ON ops.org_icon_override_log (member_id, created_at);
 
 -- ────────────────────────────────────────────────────────────────────────────
+-- 履歴表の追記オンリー強制(独立役員審査 0020 C-3)
+-- ────────────────────────────────────────────────────────────────────────────
+-- 当初は「ryza_boardroom に INSERT しか GRANT しない」だけで追記オンリーを表現して
+-- いたが、それはロール分離が効く経路(ダッシュボード)にしか効かない。テーブル所有
+-- ロール(ryza)で動くジョブ・Bot・手動の psql は履歴を UPDATE / DELETE できてしまい、
+-- 「現在値の履歴が必ず残る」という 0020 の担保が所有ロールに対しては空手形になる。
+-- 0013(governance.minutes / minute_resolutions)が確立した「トリガ + REVOKE」の
+-- 先例に揃え、権限ではなくテーブル自身の性質として追記オンリーを強制する。
+CREATE FUNCTION ops.forbid_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION
+        '% は % では禁止(追記オンリー)。アイコン上書きの変更履歴は証跡であり、訂正も追記で行う',
+        TG_OP, TG_TABLE_NAME;
+END;
+$$;
+
+CREATE TRIGGER org_icon_override_log_no_mutation
+    BEFORE UPDATE OR DELETE ON ops.org_icon_override_log
+    FOR EACH ROW EXECUTE FUNCTION ops.forbid_mutation();
+
+REVOKE UPDATE, DELETE ON ops.org_icon_override_log FROM PUBLIC;
+
+-- **TRUNCATE は行トリガを迂回する**(0015 で実証・0018 が標準化)。行トリガだけでは
+-- `TRUNCATE ops.org_icon_override_log` の一撃で履歴が全て消えるため、0018 の
+-- forbid_truncate と同型の文トリガ + REVOKE TRUNCATE で塞ぐ。
+CREATE FUNCTION ops.forbid_truncate() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION '% の TRUNCATE は禁止(追記オンリーの監査証跡)。訂正は追記で行う',
+        TG_TABLE_NAME;
+END;
+$$;
+
+CREATE TRIGGER org_icon_override_log_no_truncate
+    BEFORE TRUNCATE ON ops.org_icon_override_log
+    FOR EACH STATEMENT EXECUTE FUNCTION ops.forbid_truncate();
+
+REVOKE TRUNCATE ON ops.org_icon_override_log FROM PUBLIC;
+
+-- 現在値表(ops.org_icon_overrides)には同じ制約を掛けない。上書き・削除が本義の
+-- 可変表であり、その変更履歴は上のログ表が持つ。ただし TRUNCATE は「上書きを全部
+-- 消す」操作でありログを残さないため、0018 が trading.orders(可変表)に対して
+-- 行ったのと同じ理由で封鎖する。
+CREATE TRIGGER org_icon_overrides_no_truncate
+    BEFORE TRUNCATE ON ops.org_icon_overrides
+    FOR EACH STATEMENT EXECUTE FUNCTION ops.forbid_truncate();
+
+REVOKE TRUNCATE ON ops.org_icon_overrides FROM PUBLIC;
+
+-- ────────────────────────────────────────────────────────────────────────────
 -- 権限に関する注記(0017 との違い)
 -- ────────────────────────────────────────────────────────────────────────────
 -- 0017 の ops.discord_webhooks は「URL を知る者が誰でも投稿できる」秘密のため、

--- a/ops/deploy-dashboard.sh
+++ b/ops/deploy-dashboard.sh
@@ -303,6 +303,29 @@ SELECT count(*) AS dashboard_secret_grants
   FROM information_schema.role_table_grants
  WHERE grantee = '__DASH_ROLE__'
    AND table_schema || '.' || table_name IN ('ops.discord_webhooks');
+
+-- 役員室ロールの ops スキーマ権限(独立役員審査 0020 C-5)。上の GRANT は
+-- to_regclass ガード付きで、0020 未適用の DB では**黙ってスキップ**される。GRANT が
+-- 効いたか/余計な表に広がっていないかを、デプロイのたびにログへ残して検証する。
+\echo '-- 役員室ロールが ops で権限を持つ表(org_icon_overrides と org_icon_override_log の2表のみであること)'
+SELECT table_name, string_agg(privilege_type, ',' ORDER BY privilege_type) AS privileges
+  FROM information_schema.role_table_grants
+ WHERE grantee = '__BR_ROLE__' AND table_schema = 'ops'
+ GROUP BY table_name ORDER BY table_name;
+\echo '-- 役員室ロールの ops 権限の表数(2 であること。0 なら 0020 未適用で GRANT がスキップされた)'
+SELECT count(DISTINCT table_name) AS boardroom_ops_tables
+  FROM information_schema.role_table_grants
+ WHERE grantee = '__BR_ROLE__' AND table_schema = 'ops';
+\echo '-- 役員室ロールが ops の想定外テーブルに持つ権限(0 であること — trading_state/flags/discord_webhooks 等)'
+SELECT count(*) AS boardroom_unexpected_ops_grants
+  FROM information_schema.role_table_grants
+ WHERE grantee = '__BR_ROLE__' AND table_schema = 'ops'
+   AND table_name NOT IN ('org_icon_overrides', 'org_icon_override_log');
+\echo '-- 履歴表への非 INSERT 権限(0 であること — 追記オンリー。UPDATE/DELETE/TRUNCATE を持たない)'
+SELECT count(*) AS boardroom_log_mutation_grants
+  FROM information_schema.role_table_grants
+ WHERE grantee = '__BR_ROLE__' AND table_schema = 'ops'
+   AND table_name = 'org_icon_override_log' AND privilege_type <> 'INSERT';
 """
 
 sql = (

--- a/ops/deploy-dashboard.sh
+++ b/ops/deploy-dashboard.sh
@@ -246,6 +246,8 @@ SELECT format(
 -- 注意: ALTER DEFAULT PRIVILEGES により**将来作られるテーブルにも SELECT が付く**。
 --   秘密を持つテーブルを新設したら、この除外リストに追加すること
 --   (恒久策は ops/reminders.yaml db-role-separation-webhook-url のロール分離)。
+--   ops.org_icon_overrides / ops.org_icon_override_log(0020)は公開画像 URL のみで
+--   秘密を持たず、組織ページの表示に読取が必要なため**除外しない**(SELECT のまま)。
 SELECT format('REVOKE ALL ON %s FROM %I', t.rel, '__DASH_ROLE__')
   FROM (VALUES ('ops.discord_webhooks')) AS t(rel)
  WHERE to_regclass(t.rel) IS NOT NULL;
@@ -264,12 +266,24 @@ ALTER ROLE "__BR_ROLE__"
 ALTER ROLE "__BR_ROLE__" SET default_transaction_read_only = off;
 
 GRANT CONNECT ON DATABASE "__DB__" TO "__BR_ROLE__";
-GRANT USAGE ON SCHEMA governance, meta TO "__BR_ROLE__";
+GRANT USAGE ON SCHEMA governance, meta, ops TO "__BR_ROLE__";
 -- 着任プロンプト(stances)・決議一覧・Run の読み出しに必要な SELECT。
 GRANT SELECT ON governance.minutes, governance.minute_resolutions, governance.stances,
                 meta.runs TO "__BR_ROLE__";
 GRANT INSERT ON governance.minutes, governance.minute_resolutions, governance.stances
   TO "__BR_ROLE__";
+-- キャラクターアイコンの上書き(0020・代表指示 2026-08-03)。組織ページの編集 UI が
+-- このロールで書く。書けるのはこの 2 表だけで、ops の他の表(trading_state・flags・
+-- discord_webhooks 等)への権限は与えない — Kill Switch や webhook 秘密への経路を作らない。
+-- 現在値表は上書きが本義のため UPDATE と、初期値へ戻すための DELETE が要る。
+-- 履歴表は**追記オンリー**(INSERT のみ。UPDATE/DELETE を与えず履歴を消せなくする)。
+SELECT format('GRANT SELECT, INSERT, UPDATE, DELETE ON ops.org_icon_overrides TO %I',
+              '__BR_ROLE__')
+ WHERE to_regclass('ops.org_icon_overrides') IS NOT NULL;
+\gexec
+SELECT format('GRANT INSERT ON ops.org_icon_override_log TO %I', '__BR_ROLE__')
+ WHERE to_regclass('ops.org_icon_override_log') IS NOT NULL;
+\gexec
 -- meta.runs は開始 INSERT → 終了時に status/finished_at/cost を UPDATE する。UPDATE は
 -- **列レベル**に限定し、job_name / code_version / started_at / params の事後改竄を防ぐ
 -- (リネージの証跡性。再審査 条件3)。列名は migrations/0001_meta.sql に一致させること。

--- a/ops/reminders.yaml
+++ b/ops/reminders.yaml
@@ -344,3 +344,39 @@ reminders:
       channel: 運営
       body: "代表が OAuth 同意画面(https://console.cloud.google.com/auth/overview?project=ryza-main、アプリ名 Ryza Dashboard・External・テストユーザーに mileage_embassy_9x@icloud.com)を設定したか確認する。設定済みなら: gcloud iap oauth-clients create で OAuth クライアントを作成し IAP へ紐付け → 未認証 curl が 302 を返すこと・代表アカウントでダッシュボード(https://ryza-dashboard-weuuqovieq-uw.a.run.app)にログインできることを確認 → URL を #承認 へ報告し本リマインダーを done に。未設定なら代表へ再依頼。現状: IAP は有効で未認証は 502(IAP 生成・遮断確認済み)だが、OAuth クライアント不在のため代表もログイン不可(2026-08-03 デプロイ時のエラー『Empty Google Account OAuth client ID(s)/secret(s)』)。"
     status: pending
+
+  - id: governance-protect-deploy-dashboard
+    what: "ops/deploy-dashboard.sh を config/governance.yaml の protected_areas へ登録(独立役員審査 0020 C-4)"
+    conditions:
+      - type: date_after
+        date: "2026-08-10"
+    action:
+      type: issue_create
+      title: "protected_areas に ops/deploy-dashboard.sh を登録する"
+      labels: [governance]
+      body: "ops/deploy-dashboard.sh は DB ロールの権限定義・IAP 許可リスト・稼働コードの検証を持つ実質的なデプロイ経路だが、config/governance.yaml の protected_areas には bot/daily/ops-weekly のデプロイのみが登録されており、本スクリプトは対象外になっている(独立役員審査 0020 C-4)。そのため監査 A-13-1(無承認変更検出)が本ファイルの変更を検出せず、権限定義が承認記録なしに書き換わっても気付けない。是正: config/governance.yaml の protected_areas に ops/deploy-dashboard.sh(および deploy 経路のスクリプト群)を追加する。governance.yaml 自体が保護領域のため、独立役員審査 → #承認 通知 → 48h みなし承認の手続を経ること。0020 の PR とは別 PR にするのは、承認の単位を『スキーマ』と『統制対象の定義変更』で混ぜないため(設計リード裁定 2026-08-03)。"
+    status: pending
+
+  - id: icon-rehost-storage
+    what: "キャラクターアイコンを保存時に自前で再ホストする(独立役員審査 0020 C-6/C-7 の恒久是正)"
+    conditions:
+      - type: date_after
+        date: "2026-08-31"
+    action:
+      type: issue_create
+      title: "アイコン上書きを外部ホットリンクから自前再ホストへ移行する"
+      labels: [impl]
+      body: "現行の ops.org_icon_overrides(0020)は外部 URL のホットリンクを保存し、保存時に単発の HEAD/GET で検証するだけである。これには2つの構造的な限界がある。(1) 検証は保存時点のスナップショットでしかなく、URL 先の画像が後から差し替えられても検知できない(C-7)。(2) 実アクセスを伴う検証はそれ自体が SSRF の入口で、現行の緩和(https 限定・リダイレクト追従なし・解決先 IP が公開アドレスであることの確認)は DNS rebinding には無力である(C-6・src/ryza/org.py の _reject_internal_host に明記)。恒久是正は、保存時に画像を1度だけ取得して自前ストレージ(GCS 等)へ複製し、以後は自前 URL を配信すること。取得はサイズ上限(現行 5MB)とタイムアウト付きの1回に限定し、以後の外部アクセスを無くす。**着手前に再配布の法的懸念を整理すること**: config/org.yaml 冒頭の判断(『public リポジトリへの画像コミットは再配布にあたるため行わず icon_url のホットリンクで参照する』)は、非公開の自前ストレージへの複製が同じ問題になるかを検討していない。非公開・単一利用者・認証必須(IAP)の配信であれば私的複製の範囲と整理できる可能性があるが、結論を出してから実装すること。整理の結果『再ホストしない』となった場合は、代わりに定期的な再検証ジョブ(保存済み URL の Content-Type/サイズを週次で HEAD 確認し、変化を #運営 へ通知)を実装する。"
+    status: pending
+
+  - id: outbox-internal-key-separation
+    what: "embed author の内部キー member_id を構造的に分離する(独立役員審査 0020 C-10)"
+    conditions:
+      - type: date_after
+        date: "2026-08-31"
+    action:
+      type: issue_create
+      title: "outbox の内部キー(author.member_id)を embed_json の外へ出す"
+      labels: [impl]
+      body: "0020 は配送時にアイコン上書きを解決するため、embed_json の author に内部キー member_id を載せる方式を採った(src/ryza/org.py embed_author / AUTHOR_MEMBER_KEY)。これは press.outbox の全行に Discord API のフィールドではない値が永続化されることを意味し、除去は送信直前の1関数(org.resolve_author)だけに依存している(独立役員審査 0020 C-10)。将来 embed_json を別経路(新しい配送先・再送ツール・エクスポート)へ流す実装が resolve_author を通し忘れると、未知フィールドが Discord へ送られる。是正: press.outbox に author_member_id 列を追加する(あるいは embed_json と並ぶ meta 列を設ける)か、outbox.OutboxMessage のデータ構造として embed とは別に持ち、embed_json には Discord のフィールドだけを入れる。press.outbox はスキーマ変更のため保護領域の手続を経ること。現行方式でも実害が出ていないのは、Discord が未知フィールドを無視するためであり(0020 時点で確認)、緊急性は低い。"
+    status: pending

--- a/src/ryza/bot/main.py
+++ b/src/ryza/bot/main.py
@@ -37,6 +37,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
+from ryza import org
 from ryza.bot import CHANNELS, COLOR_FLASH, COLOR_NORMAL, channels, killswitch, outbox, webhooks
 from ryza.bot import daily as daily_mod
 from ryza.bot.approvals import KINDS, NotOwnerError, parse_proposal, record_decision
@@ -293,20 +294,25 @@ class RyzaBot(commands.Bot):
 
         def send_fn(msg: outbox.OutboxMessage) -> str:
             # 論理チャンネル → 実 ID / webhook は起動時 ensure の記録(ops.*)から解決。
+            # アイコン上書き(0020)も同じ接続で読む。**投入時ではなく配送時**に解決する
+            # ことで、代表がダッシュボードで差し替えた直後の投稿から新アイコンになる
+            # (キャッシュしない — org.icon_overrides)。
             with connect() as resolve_conn:
                 channel_id = channels.resolve(resolve_conn, msg.channel)
                 webhook_url = webhooks.resolve_webhook(resolve_conn, msg.channel)
+                overrides = org.icon_overrides(resolve_conn)
             if channel_id is None:
                 raise RuntimeError(f"チャンネル未解決(ensure 前?): {msg.channel}")
             # #承認 向けで proposal footer を持つ embed には承認ボタンを付ける
             # (凍結中の例外的取引などを1件ずつオーナー承認する経路)。
             parsed = parse_proposal(msg.embed) if msg.channel == "approval" else None
+            embed_json = org.apply_icon_overrides(msg.embed, overrides)
             # webhook 方式(代表指示 2026-08-03): author キャラクターを username /
             # avatar_url へ昇格して投稿(webhooks.py)。承認ボタン付きは webhook に
             # コンポーネントを付けられないため従来の Bot 投稿のまま。
             if webhook_url is not None and parsed is None:
-                return webhooks.post(webhook_url, msg.embed, urgent=msg.urgent)
-            embed = dict_to_embed(msg.embed)
+                return webhooks.post(webhook_url, embed_json, urgent=msg.urgent)
+            embed = dict_to_embed(embed_json)
             if msg.urgent:
                 embed.color = discord.Color(COLOR_FLASH)
             channel = self.get_channel(int(channel_id))

--- a/src/ryza/bot/main.py
+++ b/src/ryza/bot/main.py
@@ -300,7 +300,17 @@ class RyzaBot(commands.Bot):
             with connect() as resolve_conn:
                 channel_id = channels.resolve(resolve_conn, msg.channel)
                 webhook_url = webhooks.resolve_webhook(resolve_conn, msg.channel)
-                overrides = org.icon_overrides(resolve_conn)
+                try:
+                    overrides = org.icon_overrides(resolve_conn)
+                except Exception:  # noqa: BLE001 - フェイルオープン(独立役員審査 0020 C-2)
+                    # **アイコンが古いのは許容、配送停止は不許容**。ここで例外を上げると
+                    # outbox.deliver_pending が当該メッセージを送れないまま次へ進み
+                    # (無言の再試行待ち)、0020 未適用の環境や一時的な DB エラーで
+                    # 速報・Kill Switch 通報を含む全 Discord 配送が静かに止まる。
+                    # 見た目の鮮度より配送の到達性を優先し、台帳の値で送る。
+                    log.warning("アイコン上書きを読めないため台帳の値で配送する", exc_info=True)
+                    resolve_conn.rollback()  # 失敗でアボートした tx を明示的に畳む
+                    overrides = {}
             if channel_id is None:
                 raise RuntimeError(f"チャンネル未解決(ensure 前?): {msg.channel}")
             # #承認 向けで proposal footer を持つ embed には承認ボタンを付ける

--- a/src/ryza/bridge_send.py
+++ b/src/ryza/bridge_send.py
@@ -93,6 +93,11 @@ def build_embeds(
     """本文を author(名前(役職)+アイコン)付き embed 列へ組む(純関数)。
 
     タイトルは先頭 embed のみ。author は全 embed に付け、色はキャラクター色。
+
+    アイコンは**台帳(config/org.yaml)の値**を使う。DB のアイコン上書き
+    (``ops.org_icon_overrides``・0020)は適用しない — 本モジュールは psycopg 非依存の
+    軽量経路(モジュール docstring)であり、DB 接続を持たないため。開発対話用の
+    ブリッジに限った割り切りで、Bot 本体の配送(outbox 経路)は上書きに追従する。
     """
     embeds: list[dict[str, Any]] = []
     for i, chunk in enumerate(split_chunks(text)):

--- a/src/ryza/org.py
+++ b/src/ryza/org.py
@@ -23,6 +23,8 @@ Discord 向けの ``Member.icon_url`` は拡張子を ``.png`` へ読み替え�
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 import urllib.request
 from dataclasses import dataclass, replace
 from functools import lru_cache
@@ -217,18 +219,64 @@ def apply_icon_overrides(
 
 # ── アイコン URL の検証(https のみ・実体が画像であること)───────────────────
 class IconUrlError(ValueError):
-    """アイコン URL が使えない(スキーム違反・到達不能・画像でない)。"""
+    """アイコン URL が使えない(スキーム違反・到達不能・画像でない・内部宛)。"""
 
 
 # 検証の実アクセスは短時間で打ち切る(UI の保存操作を待たせない)。
 ICON_URL_TIMEOUT = 5.0
 
+# 受け入れる画像形式(独立役員審査 0020 C-8)。``image/*`` 全体を許すと ``image/svg+xml``
+# が通り、SVG は script・外部参照を含みうるマークアップである。Streamlit は SVG を
+# レンダリングするため、組織ページの閲覧者(代表)のブラウザで実行されうる。
+# Discord が表示できる形式(PNG/JPEG/GIF/WebP)に限れば実害なく塞げる。
+ICON_ALLOWED_TYPES = ("image/png", "image/jpeg", "image/gif", "image/webp")
 
-def _default_opener(url: str, method: str, timeout: float) -> str:
-    """URL へ ``method`` でアクセスし Content-Type を返す(差し替え可能な I/O)。"""
+# 上限 5MB(独立役員審査 0020 C-8)。Discord のアバターに 5MB 超の原寸画像は不要で、
+# 巨大ファイルは表示のたびに代表の回線と Discord 側の取得を無駄に使う。
+ICON_MAX_BYTES = 5 * 1024 * 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """リダイレクトを一切追従しないハンドラ(``None`` を返すと urllib は 3xx を送出)。"""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+        return None
+
+
+def _default_opener(url: str, method: str, timeout: float) -> dict[str, str]:
+    """URL へ ``method`` でアクセスし、応答ヘッダを小文字キーの dict で返す。
+
+    **リダイレクトは追従しない**(独立役員審査 0020 C-6)。追従を許すと、検証を通った
+    https の外部 URL から内部アドレスへ誘導され、検証の実アクセス自体が内部宛リクエスト
+    (SSRF)になる。3xx は ``HTTPError`` として失敗させ、利用者には最終 URL を直接
+    指定してもらう。
+    """
+    opener = urllib.request.build_opener(_NoRedirect)
     req = urllib.request.Request(url, method=method, headers={"User-Agent": "RyzaOrg/1.0"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - https 限定済み
-        return str(resp.headers.get("Content-Type", ""))
+    with opener.open(req, timeout=timeout) as resp:  # noqa: S310 - https 限定済み
+        return {str(k).lower(): str(v) for k, v in resp.headers.items()}
+
+
+def _reject_internal_host(host: str) -> None:
+    """名前解決した宛先がインターネット公開アドレスでなければ ``IconUrlError``。
+
+    暫定の SSRF 緩和(独立役員審査 0020 C-6)。``127.0.0.1`` / ``10.0.0.0/8`` /
+    ``169.254.169.254``(GCE メタデータ)等へ検証アクセスさせない。
+
+    **限界**: 検証時の名前解決と実アクセス時の名前解決は別で、DNS の応答を切り替える
+    攻撃(DNS rebinding)には無力である。恒久是正は保存時に画像を自前で再ホストして
+    外部 URL への実アクセス自体を無くすこと(ops/reminders.yaml icon-rehost-storage)。
+    """
+    try:
+        infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except OSError as exc:
+        raise IconUrlError(f"ホスト名を解決できない({host}): {exc}") from None
+    for info in infos:
+        address = ipaddress.ip_address(info[4][0])
+        if not address.is_global:
+            raise IconUrlError(
+                f"内部アドレスへ解決される URL は使えない({host} → {address})"
+            )
 
 
 def check_icon_url(
@@ -241,31 +289,53 @@ def check_icon_url(
 
     - **https のみ**(http・data:・相対 URL は拒否。Discord も Streamlit も外部から
       取得するため、平文経路とスキームの取り違えをここで塞ぐ)
-    - 実アクセスして ``Content-Type`` が ``image/*`` であること。HEAD を拒む配信元
-      (405/501)があるため HEAD → GET の順に試す
+    - **宛先がインターネット公開アドレス**であること(``_reject_internal_host``)
+    - 実アクセス(**リダイレクト追従なし**)して ``Content-Type`` が
+      ``ICON_ALLOWED_TYPES`` のいずれかであること。HEAD を拒む配信元(405/501)が
+      あるため HEAD → GET の順に試す
+    - ``Content-Length`` が ``ICON_MAX_BYTES`` 以下であること。**ヘッダが無い場合は
+      拒否する** — ボディを実際に読んで実測する経路を作ると、検証のために任意の外部
+      URL から大きなデータを取得することになり、SSRF の増幅・DoS の的になる。
+      サイズを申告しない配信元は代表に別の URL を選んでもらう方が安全で単純
     - 到達不能・タイムアウトは失敗として扱い、**保存しない**
 
-    ``opener`` は ``(url, method, timeout) -> content_type`` の差し替え口
+    ``opener`` は ``(url, method, timeout) -> 小文字キーのヘッダ dict`` の差し替え口
     (テストは実ネットワークを叩かない)。
     """
     candidate = url.strip()
     parsed = urlparse(candidate)
-    if parsed.scheme != "https" or not parsed.netloc:
+    if parsed.scheme != "https" or not parsed.hostname:
         raise IconUrlError(f"https:// の URL のみ受け付ける(受領: {candidate!r})")
     fetch = opener if opener is not None else _default_opener
-    content_type = ""
+    if opener is None:
+        # 差し替え時(テスト)は名前解決しない。実 I/O を行う既定経路だけが対象。
+        _reject_internal_host(parsed.hostname)
+    headers: dict[str, str] = {}
     errors: list[str] = []
     for method in ("HEAD", "GET"):
         try:
-            content_type = fetch(candidate, method, timeout)
+            headers = fetch(candidate, method, timeout)
             break
         except Exception as exc:  # noqa: BLE001 - 失敗理由は利用者に見せる
             errors.append(f"{method}: {type(exc).__name__}: {exc}")
     else:
         raise IconUrlError(f"URL に到達できない({' / '.join(errors)})")
-    if not content_type.split(";")[0].strip().lower().startswith("image/"):
+
+    content_type = str(headers.get("content-type", "")).split(";")[0].strip().lower()
+    if content_type not in ICON_ALLOWED_TYPES:
         raise IconUrlError(
-            f"画像ではない(Content-Type: {content_type or '(なし)'})。画像の直リンク URL を指定する"
+            f"対応していない画像形式(Content-Type: {content_type or '(なし)'})。"
+            f"{' / '.join(ICON_ALLOWED_TYPES)} の直リンク URL を指定する"
+        )
+    raw_length = str(headers.get("content-length", "")).strip()
+    if not raw_length.isdigit():
+        raise IconUrlError(
+            "サイズ(Content-Length)を申告しない URL は受け付けない。"
+            "画像の直リンク URL を指定する"
+        )
+    if int(raw_length) > ICON_MAX_BYTES:
+        raise IconUrlError(
+            f"画像が大きすぎる({int(raw_length):,} bytes > 上限 {ICON_MAX_BYTES:,} bytes)"
         )
     return candidate
 
@@ -278,11 +348,22 @@ def set_icon_override(
 
     台帳に無い ``member_id`` は ``KeyError``(存在しないキャラの上書きを作らない)。
     URL の検証は呼び出し側の責務(``check_icon_url``)— ここは DB 書込のみを行う。
-    現在値とログは**同じトランザクションで**書く(0020 の方式 B の担保)。
+
+    現在値とログは ``conn.transaction()`` で明示的に囲む(独立役員審査 0020 C-1)。
+    本番の呼び出し元(``queries.connect_boardroom``)は **autocommit=True** の接続で、
+    囲まないと 2 文が別トランザクションになり、ログ INSERT が失敗しても現在値だけが
+    残る。それは 0020 が方式 B の担保として掲げた「同一トランザクション」の不成立
+    であり、履歴の無い上書き=改竄と区別できない状態を作る。``transaction()`` は
+    autocommit / 非 autocommit のどちらの接続でも 1 単位に束ねる。
+
+    **非 autocommit の呼び出し元への注意**: psycopg の ``transaction()`` は、
+    トランザクションが未開始なら BEGIN して**ブロック脱出時に COMMIT する**。既に
+    トランザクション中なら SAVEPOINT として振る舞い、commit の判断は呼び出し元に残る。
+    したがって本関数を「その接続の最初の文」として呼ぶと即時確定する。
     """
     if member_id not in members(path):
         raise KeyError(f"config/org.yaml に id='{member_id}' のメンバーがいない")
-    with conn.cursor() as cur:
+    with conn.transaction(), conn.cursor() as cur:
         cur.execute(
             """
             INSERT INTO ops.org_icon_overrides (member_id, icon_url, updated_by, updated_at)
@@ -328,8 +409,10 @@ def clear_icon_override(conn: Any, member_id: str, actor: str) -> bool:
     """上書きを削除して台帳の初期値へ戻す。削除した行があれば True。
 
     上書きが無い場合も履歴は残さない(状態が変わっていないため)。
+    削除とログを ``conn.transaction()`` で束ねる理由は ``set_icon_override`` と同じ
+    (独立役員審査 0020 C-1 — autocommit 接続で削除だけが残る経路を塞ぐ)。
     """
-    with conn.cursor() as cur:
+    with conn.transaction(), conn.cursor() as cur:
         cur.execute(
             "DELETE FROM ops.org_icon_overrides WHERE member_id = %s RETURNING member_id",
             (member_id,),
@@ -348,6 +431,8 @@ def clear_icon_override(conn: Any, member_id: str, actor: str) -> bool:
 
 __all__ = [
     "AUTHOR_MEMBER_KEY",
+    "ICON_ALLOWED_TYPES",
+    "ICON_MAX_BYTES",
     "ICON_URL_TIMEOUT",
     "IconUrlError",
     "Member",

--- a/src/ryza/org.py
+++ b/src/ryza/org.py
@@ -12,13 +12,23 @@ Discord 向けの ``Member.icon_url`` は拡張子を ``.png`` へ読み替え�
 未生成の間この URL は 404 になるが、Discord はアイコン取得に失敗しても名前だけで author を
 表示するため embed 自体は成立する。Streamlit(役員室チャット)は SVG を表示できるため、
 ローカルの SVG パス(``Member.icon_repo_path``)をそのまま使う。
+
+**アイコンの実行時上書き(0020・代表指示 2026-08-03)**: 代表はダッシュボードの組織ページから
+アイコンを差し替えられる。上書きは ``ops.org_icon_overrides`` に入り、``conn`` を渡した
+呼び出し(``effective_members`` / ``get_member(..., conn=...)`` 等)でのみ台帳の上に重なる。
+``conn`` を渡さない呼び出しは従来どおり YAML そのままで、DB を持たない経路
+(``bridge_send`` 等)は影響を受けない。**上書きはキャッシュしない** — 保存直後の投稿・
+描画に必ず反映させるため、読取のたびに PK 1 行の SELECT を行う(0020 の履歴方式の注記参照)。
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import urllib.request
+from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -28,6 +38,10 @@ _CONFIG_PATH = _REPO_ROOT / "config" / "org.yaml"
 
 # GitHub raw のベース URL。embed アイコンは Discord 側が取得するため公開 URL が必要。
 _RAW_BASE = "https://raw.githubusercontent.com/klonyapin/ryza/main/"
+
+# embed の author に載せる内部キー(0020)。Discord API のフィールドではないため、
+# 配送直前に ``resolve_author`` が取り除く。
+AUTHOR_MEMBER_KEY = "member_id"
 
 
 @dataclass(frozen=True)
@@ -87,52 +101,267 @@ def _load(path: str) -> tuple[Member, ...]:
 
 
 def members(path: str | Path = _CONFIG_PATH) -> dict[str, Member]:
-    """全メンバー(id → Member)。"""
+    """全メンバー(id → Member)。台帳(YAML)そのまま — DB 上書きは適用しない。"""
     return {m.id: m for m in _load(str(path))}
 
 
-def get_member(member_id: str, path: str | Path = _CONFIG_PATH) -> Member:
+def effective_members(
+    conn: Any | None = None, path: str | Path = _CONFIG_PATH
+) -> dict[str, Member]:
+    """台帳に DB のアイコン上書き(0020)を重ねた実効メンバー(id → Member)。
+
+    ``conn`` が None なら ``members()`` と同じ(後方互換 — DB を持たない経路のため)。
+    台帳に無い ``member_id`` の上書き行は**無視**する(YAML が正。消えたキャラの
+    残骸を表示に混ぜない)。
+    """
+    base = members(path)
+    if conn is None:
+        return base
+    merged = dict(base)
+    for member_id, icon_url in icon_overrides(conn).items():
+        current = merged.get(member_id)
+        if current is None:
+            continue  # 台帳に無い id(改名・削除の残骸)は無視する
+        merged[member_id] = replace(current, icon_url=icon_url)
+    return merged
+
+
+def get_member(
+    member_id: str, path: str | Path = _CONFIG_PATH, *, conn: Any | None = None
+) -> Member:
     """id でメンバーを引く。台帳に無い id は即例外(黙って既定人格を出さない)。"""
     try:
-        return members(path)[member_id]
+        return effective_members(conn, path)[member_id]
     except KeyError as exc:
         raise KeyError(f"config/org.yaml に id='{member_id}' のメンバーがいない") from exc
 
 
-def member_for_role(role: str, path: str | Path = _CONFIG_PATH) -> Member:
+def member_for_role(
+    role: str, path: str | Path = _CONFIG_PATH, *, conn: Any | None = None
+) -> Member:
     """役職キー(cio / independent_officer / audit 等)から担当メンバーを引く。
 
     対応表を二重管理せず、台帳の ``persona`` フィールド
     (``personas/<役職キーをハイフン化>`` — personas.py の命名規約)で解決する。
     """
     persona = "personas/" + role.replace("_", "-")
-    for m in _load(str(path)):
+    for m in effective_members(conn, path).values():
         if m.persona == persona:
             return m
     raise KeyError(f"config/org.yaml に persona='{persona}' のメンバーがいない")
 
 
-def embed_author(member_id: str, path: str | Path = _CONFIG_PATH) -> dict[str, str]:
+def embed_author(
+    member_id: str, path: str | Path = _CONFIG_PATH, *, conn: Any | None = None
+) -> dict[str, str]:
     """Discord embed の author dict(「名前(役職)」+アイコン URL)。
 
     報道部(aya)・監査(tanya)の embed 構築が使う共通ヘルパ。T-015 の
     リスクレポート等、今後の embed もここを通す(名前・役職のハードコード禁止)。
+
+    ``member_id`` を内部キーとして同梱する(``AUTHOR_MEMBER_KEY``)。配送時に Bot が
+    最新のアイコン上書きへ解決し直すために必要で、Discord へ送る直前に
+    ``resolve_author`` が取り除く(Discord API へは渡らない)。
     """
-    m = get_member(member_id, path)
-    return {"name": m.display_name, "icon_url": m.icon_url}
+    m = get_member(member_id, path, conn=conn)
+    return {"name": m.display_name, "icon_url": m.icon_url, AUTHOR_MEMBER_KEY: m.id}
 
 
-def author_for_role(role: str, path: str | Path = _CONFIG_PATH) -> dict[str, str]:
+def author_for_role(
+    role: str, path: str | Path = _CONFIG_PATH, *, conn: Any | None = None
+) -> dict[str, str]:
     """役職キーから embed author dict を引く(台帳のキャラ改名・id 変更に自動追従)。"""
-    m = member_for_role(role, path)
-    return {"name": m.display_name, "icon_url": m.icon_url}
+    m = member_for_role(role, path, conn=conn)
+    return {"name": m.display_name, "icon_url": m.icon_url, AUTHOR_MEMBER_KEY: m.id}
+
+
+# ── アイコン上書き(0020)─────────────────────────────────────────────────────
+def icon_overrides(conn: Any) -> dict[str, str]:
+    """``ops.org_icon_overrides`` の現在値(member_id → icon_url)。
+
+    即反映のためキャッシュしない(0020 の履歴方式の注記)。読取専用ロール
+    (``ryza_dashboard``)でも実行できる SELECT のみ。
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT member_id, icon_url FROM ops.org_icon_overrides")
+        return {row[0]: row[1] for row in cur.fetchall()}
+
+
+def resolve_author(
+    author: dict[str, Any], overrides: dict[str, str]
+) -> dict[str, Any]:
+    """配送直前に author の ``icon_url`` を最新の上書きへ差し替える(純関数)。
+
+    ``member_id`` は内部キーなので常に取り除く(Discord へ未知フィールドを送らない)。
+    上書きが無い/古い embed(member_id 無し)はそのまま通す。
+    """
+    resolved = {k: v for k, v in author.items() if k != AUTHOR_MEMBER_KEY}
+    member_id = author.get(AUTHOR_MEMBER_KEY)
+    if member_id and member_id in overrides:
+        resolved["icon_url"] = overrides[member_id]
+    return resolved
+
+
+def apply_icon_overrides(
+    embed: dict[str, Any], overrides: dict[str, str]
+) -> dict[str, Any]:
+    """embed(dict)の author に上書きを適用した新しい dict を返す(純関数)。
+
+    author を持たない embed(起動通知など)はそのまま返す。
+    """
+    author = embed.get("author")
+    if not isinstance(author, dict):
+        return embed
+    return {**embed, "author": resolve_author(author, overrides)}
+
+
+# ── アイコン URL の検証(https のみ・実体が画像であること)───────────────────
+class IconUrlError(ValueError):
+    """アイコン URL が使えない(スキーム違反・到達不能・画像でない)。"""
+
+
+# 検証の実アクセスは短時間で打ち切る(UI の保存操作を待たせない)。
+ICON_URL_TIMEOUT = 5.0
+
+
+def _default_opener(url: str, method: str, timeout: float) -> str:
+    """URL へ ``method`` でアクセスし Content-Type を返す(差し替え可能な I/O)。"""
+    req = urllib.request.Request(url, method=method, headers={"User-Agent": "RyzaOrg/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - https 限定済み
+        return str(resp.headers.get("Content-Type", ""))
+
+
+def check_icon_url(
+    url: str,
+    *,
+    opener: Any | None = None,
+    timeout: float = ICON_URL_TIMEOUT,
+) -> str:
+    """アイコン URL を検証して正規化した URL を返す。不可なら ``IconUrlError``。
+
+    - **https のみ**(http・data:・相対 URL は拒否。Discord も Streamlit も外部から
+      取得するため、平文経路とスキームの取り違えをここで塞ぐ)
+    - 実アクセスして ``Content-Type`` が ``image/*`` であること。HEAD を拒む配信元
+      (405/501)があるため HEAD → GET の順に試す
+    - 到達不能・タイムアウトは失敗として扱い、**保存しない**
+
+    ``opener`` は ``(url, method, timeout) -> content_type`` の差し替え口
+    (テストは実ネットワークを叩かない)。
+    """
+    candidate = url.strip()
+    parsed = urlparse(candidate)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise IconUrlError(f"https:// の URL のみ受け付ける(受領: {candidate!r})")
+    fetch = opener if opener is not None else _default_opener
+    content_type = ""
+    errors: list[str] = []
+    for method in ("HEAD", "GET"):
+        try:
+            content_type = fetch(candidate, method, timeout)
+            break
+        except Exception as exc:  # noqa: BLE001 - 失敗理由は利用者に見せる
+            errors.append(f"{method}: {type(exc).__name__}: {exc}")
+    else:
+        raise IconUrlError(f"URL に到達できない({' / '.join(errors)})")
+    if not content_type.split(";")[0].strip().lower().startswith("image/"):
+        raise IconUrlError(
+            f"画像ではない(Content-Type: {content_type or '(なし)'})。画像の直リンク URL を指定する"
+        )
+    return candidate
+
+
+# ── 上書きの書込(ダッシュボード組織ページ — ryza_boardroom ロール)──────────
+def set_icon_override(
+    conn: Any, member_id: str, icon_url: str, actor: str, *, path: str | Path = _CONFIG_PATH
+) -> None:
+    """アイコン上書きを保存し、変更履歴を 1 行残す(呼び出し側が commit / autocommit)。
+
+    台帳に無い ``member_id`` は ``KeyError``(存在しないキャラの上書きを作らない)。
+    URL の検証は呼び出し側の責務(``check_icon_url``)— ここは DB 書込のみを行う。
+    現在値とログは**同じトランザクションで**書く(0020 の方式 B の担保)。
+    """
+    if member_id not in members(path):
+        raise KeyError(f"config/org.yaml に id='{member_id}' のメンバーがいない")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO ops.org_icon_overrides (member_id, icon_url, updated_by, updated_at)
+            VALUES (%s, %s, %s, now())
+            ON CONFLICT (member_id) DO UPDATE
+            SET icon_url = EXCLUDED.icon_url,
+                updated_by = EXCLUDED.updated_by,
+                updated_at = now()
+            """,
+            (member_id, icon_url, actor),
+        )
+        cur.execute(
+            """
+            INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)
+            VALUES (%s, 'set', %s, %s)
+            """,
+            (member_id, icon_url, actor),
+        )
+
+
+def update_icon(
+    conn: Any,
+    member_id: str,
+    url: str,
+    actor: str,
+    *,
+    opener: Any | None = None,
+    timeout: float = ICON_URL_TIMEOUT,
+    path: str | Path = _CONFIG_PATH,
+) -> str:
+    """URL を検証してから上書きを保存する。**検証に失敗したら書き込まない**。
+
+    ダッシュボードの保存ボタンが呼ぶ入口。検証(``check_icon_url``)と書込
+    (``set_icon_override``)を必ずこの順で結び、「検証を飛ばして保存する」経路を
+    UI 側に作らせない。
+    """
+    checked = check_icon_url(url, opener=opener, timeout=timeout)
+    set_icon_override(conn, member_id, checked, actor, path=path)
+    return checked
+
+
+def clear_icon_override(conn: Any, member_id: str, actor: str) -> bool:
+    """上書きを削除して台帳の初期値へ戻す。削除した行があれば True。
+
+    上書きが無い場合も履歴は残さない(状態が変わっていないため)。
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM ops.org_icon_overrides WHERE member_id = %s RETURNING member_id",
+            (member_id,),
+        )
+        if cur.fetchone() is None:
+            return False
+        cur.execute(
+            """
+            INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)
+            VALUES (%s, 'reset', NULL, %s)
+            """,
+            (member_id, actor),
+        )
+    return True
 
 
 __all__ = [
+    "AUTHOR_MEMBER_KEY",
+    "ICON_URL_TIMEOUT",
+    "IconUrlError",
     "Member",
+    "apply_icon_overrides",
     "author_for_role",
+    "check_icon_url",
+    "clear_icon_override",
+    "effective_members",
     "embed_author",
     "get_member",
+    "icon_overrides",
     "member_for_role",
     "members",
+    "resolve_author",
+    "set_icon_override",
+    "update_icon",
 ]

--- a/tests/ops/test_org_icon_overrides.py
+++ b/tests/ops/test_org_icon_overrides.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 import psycopg
 import pytest
 
@@ -20,12 +22,67 @@ _URL_B = "https://example.test/b.png"
 
 @pytest.fixture
 def conn(migrated_db):
+    """rollback で隔離する接続。
+
+    **先に 1 文実行してトランザクションを開いておく**のが要点。psycopg の
+    ``conn.transaction()`` は、トランザクションが未開始なら BEGIN して**ブロック脱出時に
+    COMMIT する**(= テストの rollback 隔離が効かなくなる)一方、既にトランザクション中なら
+    SAVEPOINT として振る舞う。書込ヘルパ(C-1 で transaction ブロックを持つ)を
+    rollback 隔離下で検証するため、後者の状態にしてから渡す。
+    """
     c = connect()
+    c.execute("SELECT 1")  # トランザクションを開始させる(上記の理由)
     try:
         yield c
     finally:
         c.rollback()
         c.close()
+
+
+@pytest.fixture
+def autocommit_conn(migrated_db):
+    """**本番と同じ autocommit=True の接続**(``queries.connect_boardroom`` 相当)。
+
+    独立役員審査 0020 C-1: 非 autocommit の接続では、ヘルパが transaction ブロックを
+    持たなくてもテスト側の rollback で原子性があるように見えてしまい、本番経路の欠陥を
+    検出できない。autocommit では各文が即時確定するため、``conn.transaction()`` が
+    無ければ「現在値だけ残る」がそのまま観測される。
+
+    rollback による隔離が効かないので、後片付けは明示的に行う(履歴表は追記オンリー
+    トリガで DELETE できないため、テーブル所有ロールでトリガを一時的に無効化して消す)。
+    """
+    c = connect(autocommit=True)
+    try:
+        yield c
+    finally:
+        with c.cursor() as cur:
+            cur.execute("DELETE FROM ops.org_icon_overrides WHERE member_id = 'aya'")
+            cur.execute("ALTER TABLE ops.org_icon_override_log DISABLE TRIGGER USER")
+            cur.execute("DELETE FROM ops.org_icon_override_log WHERE member_id = 'aya'")
+            cur.execute("ALTER TABLE ops.org_icon_override_log ENABLE TRIGGER USER")
+        c.close()
+
+
+@contextmanager
+def _log_writes_blocked(conn):
+    """履歴表への INSERT を失敗させる(現在値がロールバックされることの検証用)。"""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE FUNCTION ops._test_block_log() RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN RAISE EXCEPTION 'test: 履歴表への書込を意図的に失敗させた'; END; $$
+            """
+        )
+        cur.execute(
+            "CREATE TRIGGER _test_block_log BEFORE INSERT ON ops.org_icon_override_log"
+            " FOR EACH ROW EXECUTE FUNCTION ops._test_block_log()"
+        )
+    try:
+        yield
+    finally:
+        with conn.cursor() as cur:
+            cur.execute("DROP TRIGGER IF EXISTS _test_block_log ON ops.org_icon_override_log")
+            cur.execute("DROP FUNCTION IF EXISTS ops._test_block_log()")
 
 
 def _log(conn, member_id: str) -> list[tuple[str, str | None, str]]:
@@ -80,10 +137,14 @@ def test_set_rejects_member_id_absent_from_ledger(conn):
 
 
 # ── update_icon(検証 → 保存の結線)──────────────────────────────────────────
+def _headers(content_type: str) -> dict[str, str]:
+    return {"content-type": content_type, "content-length": "1024"}
+
+
 def test_update_icon_saves_after_validation(conn):
     org.update_icon(
         conn, "aya", _URL_A, "representative",
-        opener=lambda url, method, timeout: "image/png",
+        opener=lambda url, method, timeout: _headers("image/png"),
     )
     assert org.icon_overrides(conn)["aya"] == _URL_A
 
@@ -92,33 +153,103 @@ def test_update_icon_does_not_write_when_validation_fails(conn):
     with pytest.raises(org.IconUrlError):
         org.update_icon(
             conn, "aya", "https://example.test/page", "representative",
-            opener=lambda url, method, timeout: "text/html",
+            opener=lambda url, method, timeout: _headers("text/html"),
         )
     assert org.icon_overrides(conn) == {}
     assert _log(conn, "aya") == []
 
 
 # ── スキーマ制約 ──────────────────────────────────────────────────────────────
+def _expect_rejected(conn, sql: str, error):
+    """``sql`` が ``error`` で拒否されることを検証する(SAVEPOINT で外側の tx を守る)。
+
+    ``conn.rollback()`` で復旧すると外側のトランザクションごと閉じてしまい、以降の
+    書込ヘルパの ``transaction()`` が「未開始 → BEGIN → 脱出時 COMMIT」に化けて
+    テストデータがテスト DB に残る。エラーからの復旧は必ず SAVEPOINT で行う。
+    """
+    with pytest.raises(error), conn.transaction():
+        conn.execute(sql)
+
+
 def test_https_check_blocks_plain_http(conn):
     """アプリを迂回した書込でも http は入らない(最後の防壁)。"""
-    with conn.cursor() as cur, pytest.raises(psycopg.errors.CheckViolation):
-        cur.execute(
-            "INSERT INTO ops.org_icon_overrides (member_id, icon_url, updated_by)"
-            " VALUES ('aya', 'http://x/a.png', 'representative')"
-        )
-    conn.rollback()
+    _expect_rejected(
+        conn,
+        "INSERT INTO ops.org_icon_overrides (member_id, icon_url, updated_by)"
+        " VALUES ('aya', 'http://x/a.png', 'representative')",
+        psycopg.errors.CheckViolation,
+    )
+
+
+def test_append_only_log_rejects_update_and_delete(conn):
+    """履歴表は所有ロールでも書き換えられない(トリガで強制 — C-3)。"""
+    org.set_icon_override(conn, "aya", _URL_A, "representative")
+    _expect_rejected(
+        conn,
+        "UPDATE ops.org_icon_override_log SET icon_url = 'https://x/z.png'",
+        psycopg.errors.RaiseException,
+    )
+    _expect_rejected(
+        conn, "DELETE FROM ops.org_icon_override_log", psycopg.errors.RaiseException
+    )
+    assert _log(conn, "aya") == [("set", _URL_A, "representative")]  # 履歴は無傷
+
+
+def test_truncate_is_blocked_on_both_tables(conn):
+    """TRUNCATE は行トリガを迂回するため文トリガで塞ぐ(0018 の先例 — C-3)。"""
+    for table in ("ops.org_icon_override_log", "ops.org_icon_overrides"):
+        _expect_rejected(conn, f"TRUNCATE {table}", psycopg.errors.RaiseException)  # noqa: S608
 
 
 def test_log_action_and_url_must_agree(conn):
-    with conn.cursor() as cur, pytest.raises(psycopg.errors.CheckViolation):
-        cur.execute(
-            "INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)"
-            " VALUES ('aya', 'reset', 'https://x/a.png', 'representative')"
-        )
-    conn.rollback()
-    with conn.cursor() as cur, pytest.raises(psycopg.errors.CheckViolation):
-        cur.execute(
-            "INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)"
-            " VALUES ('aya', 'set', NULL, 'representative')"
-        )
-    conn.rollback()
+    _expect_rejected(
+        conn,
+        "INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)"
+        " VALUES ('aya', 'reset', 'https://x/a.png', 'representative')",
+        psycopg.errors.CheckViolation,
+    )
+    _expect_rejected(
+        conn,
+        "INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)"
+        " VALUES ('aya', 'set', NULL, 'representative')",
+        psycopg.errors.CheckViolation,
+    )
+
+
+# ── 原子性(独立役員審査 0020 C-1)──────────────────────────────────────────
+# 本番の役員室接続は autocommit=True。ヘルパが conn.transaction() で囲まないと
+# 「現在値だけ確定し履歴が無い」状態が残る(方式 B の担保が不成立になる)。
+def test_set_rolls_back_current_value_when_log_write_fails(autocommit_conn):
+    conn = autocommit_conn
+    with _log_writes_blocked(conn), pytest.raises(psycopg.errors.RaiseException):
+        org.set_icon_override(conn, "aya", _URL_A, "representative")
+    assert "aya" not in org.icon_overrides(conn)  # 現在値も残っていない
+    assert _log(conn, "aya") == []
+
+
+def test_update_rolls_back_to_previous_value_when_log_write_fails(autocommit_conn):
+    """既に上書きがある場合、失敗した更新は**前の値のまま**でなければならない。"""
+    conn = autocommit_conn
+    org.set_icon_override(conn, "aya", _URL_A, "representative")
+    with _log_writes_blocked(conn), pytest.raises(psycopg.errors.RaiseException):
+        org.set_icon_override(conn, "aya", _URL_B, "representative")
+    assert org.icon_overrides(conn)["aya"] == _URL_A
+    assert _log(conn, "aya") == [("set", _URL_A, "representative")]
+
+
+def test_clear_rolls_back_deletion_when_log_write_fails(autocommit_conn):
+    conn = autocommit_conn
+    org.set_icon_override(conn, "aya", _URL_A, "representative")
+    with _log_writes_blocked(conn), pytest.raises(psycopg.errors.RaiseException):
+        org.clear_icon_override(conn, "aya", "representative")
+    assert org.icon_overrides(conn)["aya"] == _URL_A  # 削除が巻き戻っている
+
+
+def test_autocommit_writes_persist_without_explicit_commit(autocommit_conn):
+    """transaction() で囲んでも autocommit 接続では抜けた時点で確定する(別接続から見える)。"""
+    org.set_icon_override(autocommit_conn, "aya", _URL_A, "representative")
+    other = connect()
+    try:
+        assert org.icon_overrides(other)["aya"] == _URL_A
+    finally:
+        other.close()

--- a/tests/ops/test_org_icon_overrides.py
+++ b/tests/ops/test_org_icon_overrides.py
@@ -1,0 +1,124 @@
+"""アイコン上書き(migration 0020)の DB 層テスト。
+
+代表指示 2026-08-03「キャラクターアイコンをダッシュボードから再設定できるように」。
+現在値表 ``ops.org_icon_overrides`` と追記オンリーの履歴表
+``ops.org_icon_override_log`` の対(0020 の方式 B)が、上書き・更新・削除の
+どの経路でも履歴を残すことを検証する。テスト DB に対して実行し commit しない。
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from ryza import org
+from ryza.db.conn import connect
+
+_URL_A = "https://example.test/a.png"
+_URL_B = "https://example.test/b.png"
+
+
+@pytest.fixture
+def conn(migrated_db):
+    c = connect()
+    try:
+        yield c
+    finally:
+        c.rollback()
+        c.close()
+
+
+def _log(conn, member_id: str) -> list[tuple[str, str | None, str]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT action, icon_url, actor FROM ops.org_icon_override_log
+             WHERE member_id = %s ORDER BY id
+            """,
+            (member_id,),
+        )
+        return cur.fetchall()
+
+
+# ── 保存・更新・削除 ──────────────────────────────────────────────────────────
+def test_set_override_is_visible_to_loader(conn):
+    org.set_icon_override(conn, "aya", _URL_A, "representative")
+    assert org.icon_overrides(conn)["aya"] == _URL_A
+    assert org.effective_members(conn)["aya"].icon_url == _URL_A
+
+
+def test_update_overwrites_current_value_but_log_keeps_history(conn):
+    """UPDATE で現在値は 1 行に保たれるが、履歴は両方残る(0020 の方式 B の要件)。"""
+    org.set_icon_override(conn, "aya", _URL_A, "representative")
+    org.set_icon_override(conn, "aya", _URL_B, "representative")
+    assert org.icon_overrides(conn)["aya"] == _URL_B
+    assert _log(conn, "aya") == [
+        ("set", _URL_A, "representative"),
+        ("set", _URL_B, "representative"),
+    ]
+
+
+def test_clear_restores_ledger_value_and_logs_reset(conn):
+    org.set_icon_override(conn, "aya", _URL_A, "representative")
+    assert org.clear_icon_override(conn, "aya", "representative") is True
+    assert "aya" not in org.icon_overrides(conn)
+    # 台帳(config/org.yaml)の初期値へ戻る。
+    assert org.effective_members(conn)["aya"].icon_url == org.members()["aya"].icon_url
+    assert _log(conn, "aya")[-1] == ("reset", None, "representative")
+
+
+def test_clear_without_override_is_noop(conn):
+    assert org.clear_icon_override(conn, "aya", "representative") is False
+    assert _log(conn, "aya") == []
+
+
+def test_set_rejects_member_id_absent_from_ledger(conn):
+    """台帳に無い id の上書きは作らない(存在しないキャラの行を残さない)。"""
+    with pytest.raises(KeyError):
+        org.set_icon_override(conn, "ghost", _URL_A, "representative")
+    assert org.icon_overrides(conn) == {}
+
+
+# ── update_icon(検証 → 保存の結線)──────────────────────────────────────────
+def test_update_icon_saves_after_validation(conn):
+    org.update_icon(
+        conn, "aya", _URL_A, "representative",
+        opener=lambda url, method, timeout: "image/png",
+    )
+    assert org.icon_overrides(conn)["aya"] == _URL_A
+
+
+def test_update_icon_does_not_write_when_validation_fails(conn):
+    with pytest.raises(org.IconUrlError):
+        org.update_icon(
+            conn, "aya", "https://example.test/page", "representative",
+            opener=lambda url, method, timeout: "text/html",
+        )
+    assert org.icon_overrides(conn) == {}
+    assert _log(conn, "aya") == []
+
+
+# ── スキーマ制約 ──────────────────────────────────────────────────────────────
+def test_https_check_blocks_plain_http(conn):
+    """アプリを迂回した書込でも http は入らない(最後の防壁)。"""
+    with conn.cursor() as cur, pytest.raises(psycopg.errors.CheckViolation):
+        cur.execute(
+            "INSERT INTO ops.org_icon_overrides (member_id, icon_url, updated_by)"
+            " VALUES ('aya', 'http://x/a.png', 'representative')"
+        )
+    conn.rollback()
+
+
+def test_log_action_and_url_must_agree(conn):
+    with conn.cursor() as cur, pytest.raises(psycopg.errors.CheckViolation):
+        cur.execute(
+            "INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)"
+            " VALUES ('aya', 'reset', 'https://x/a.png', 'representative')"
+        )
+    conn.rollback()
+    with conn.cursor() as cur, pytest.raises(psycopg.errors.CheckViolation):
+        cur.execute(
+            "INSERT INTO ops.org_icon_override_log (member_id, action, icon_url, actor)"
+            " VALUES ('aya', 'set', NULL, 'representative')"
+        )
+    conn.rollback()

--- a/tests/test_org.py
+++ b/tests/test_org.py
@@ -1,10 +1,43 @@
-"""org — 組織メンバー台帳ローダ(config/org.yaml v2)のテスト。DB 不要の純ロジック。"""
+"""org — 組織メンバー台帳ローダ(config/org.yaml v2)のテスト。
+
+台帳の読取・役職解決・author 組立は DB 不要の純ロジック。アイコン上書き(0020)の
+マージ・URL 検証も、DB とネットワークをフェイクで差し替えて DB 無しで検証する
+(実 DB を使う保存/履歴の検証は tests/ops/test_org_icon_overrides.py)。
+"""
 
 from __future__ import annotations
 
 import pytest
 
 from ryza import org
+
+
+class _FakeCursor:
+    """``ops.org_icon_overrides`` の SELECT だけに答える最小のカーソル。"""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.queries: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self.queries.append(sql)
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, overrides: dict[str, str]):
+        self.cursor_obj = _FakeCursor(list(overrides.items()))
+
+    def cursor(self):
+        return self.cursor_obj
 
 
 def test_members_loaded_from_ledger():
@@ -77,3 +110,123 @@ def test_embed_author_shape():
 def test_author_for_role_follows_ledger_rename():
     author = org.author_for_role("audit")
     assert author["name"] == "ターニャ(監査部門)"
+
+
+def test_embed_author_carries_member_id_for_delivery_time_resolution():
+    """配送時に上書きを引けるよう、author は内部キー member_id を運ぶ(0020)。"""
+    assert org.embed_author("aya")[org.AUTHOR_MEMBER_KEY] == "aya"
+    assert org.author_for_role("audit")[org.AUTHOR_MEMBER_KEY] == "tanya"
+
+
+# ── アイコン上書きのマージ(0020)─────────────────────────────────────────────
+def test_effective_members_without_conn_is_yaml_only():
+    """conn を渡さない呼び出しは従来どおり台帳そのまま(後方互換)。"""
+    assert org.effective_members() == org.members()
+    assert org.effective_members(None)["aya"].icon_url == org.members()["aya"].icon_url
+
+
+def test_effective_members_applies_db_override():
+    conn = _FakeConn({"aya": "https://example.test/new-aya.png"})
+    merged = org.effective_members(conn)
+    assert merged["aya"].icon_url == "https://example.test/new-aya.png"
+    # 上書きされるのは icon_url だけ(名前・色・役職は台帳のまま)。
+    assert merged["aya"].name == org.members()["aya"].name
+    assert merged["aya"].color == org.members()["aya"].color
+    # 上書きの無いメンバーは台帳のまま。
+    assert merged["tanya"].icon_url == org.members()["tanya"].icon_url
+
+
+def test_effective_members_ignores_unknown_member_id():
+    """台帳に無い id の上書き行は無視する(消えたキャラの残骸を表示に混ぜない)。"""
+    conn = _FakeConn({"ghost": "https://example.test/ghost.png", "aya": "https://e.test/a.png"})
+    merged = org.effective_members(conn)
+    assert "ghost" not in merged
+    assert merged["aya"].icon_url == "https://e.test/a.png"
+
+
+def test_get_member_and_authors_follow_override():
+    conn = _FakeConn({"tanya": "https://example.test/tanya.png"})
+    assert org.get_member("tanya", conn=conn).icon_url == "https://example.test/tanya.png"
+    assert org.member_for_role("audit", conn=conn).icon_url == "https://example.test/tanya.png"
+    assert org.author_for_role("audit", conn=conn)["icon_url"] == "https://example.test/tanya.png"
+
+
+# ── 配送時の解決(純関数)──────────────────────────────────────────────────────
+def test_resolve_author_replaces_icon_and_strips_internal_key():
+    author = {"name": "射命丸 文(報道部アナリスト)", "icon_url": "https://old/x.png",
+              org.AUTHOR_MEMBER_KEY: "aya"}
+    resolved = org.resolve_author(author, {"aya": "https://new/y.png"})
+    assert resolved == {"name": "射命丸 文(報道部アナリスト)", "icon_url": "https://new/y.png"}
+
+
+def test_resolve_author_strips_internal_key_even_without_override():
+    """member_id は Discord API のフィールドではないため常に落とす。"""
+    author = {"name": "n", "icon_url": "https://old/x.png", org.AUTHOR_MEMBER_KEY: "aya"}
+    assert org.resolve_author(author, {}) == {"name": "n", "icon_url": "https://old/x.png"}
+
+
+def test_apply_icon_overrides_on_embed():
+    embed = {"title": "朝刊", "author": org.embed_author("aya"), "color": 1}
+    out = org.apply_icon_overrides(embed, {"aya": "https://new/y.png"})
+    assert out["author"]["icon_url"] == "https://new/y.png"
+    assert org.AUTHOR_MEMBER_KEY not in out["author"]
+    assert out["title"] == "朝刊" and out["color"] == 1
+    assert embed["author"][org.AUTHOR_MEMBER_KEY] == "aya"  # 元の dict は壊さない
+
+
+def test_apply_icon_overrides_passthrough_without_author():
+    embed = {"title": "起動通知", "color": 1}
+    assert org.apply_icon_overrides(embed, {"aya": "https://new/y.png"}) == embed
+
+
+# ── URL 検証 ─────────────────────────────────────────────────────────────────
+def _opener(content_type: str, *, fail_head: bool = False):
+    calls: list[tuple[str, str]] = []
+
+    def _fake(url: str, method: str, timeout: float) -> str:
+        calls.append((url, method))
+        if fail_head and method == "HEAD":
+            raise OSError("405 Method Not Allowed")
+        return content_type
+
+    _fake.calls = calls  # type: ignore[attr-defined]
+    return _fake
+
+
+def test_check_icon_url_accepts_https_image():
+    opener = _opener("image/png")
+    assert org.check_icon_url(" https://x.test/a.png ", opener=opener) == "https://x.test/a.png"
+    assert opener.calls == [("https://x.test/a.png", "HEAD")]
+
+
+def test_check_icon_url_accepts_content_type_with_charset():
+    assert org.check_icon_url("https://x.test/a.jpg", opener=_opener("image/jpeg; charset=binary"))
+
+
+@pytest.mark.parametrize(
+    "url", ["http://x.test/a.png", "ftp://x.test/a.png", "data:image/png;base64,AA", "/a.png"]
+)
+def test_check_icon_url_rejects_non_https(url):
+    opener = _opener("image/png")
+    with pytest.raises(org.IconUrlError):
+        org.check_icon_url(url, opener=opener)
+    assert opener.calls == []  # 実アクセスの前に弾く
+
+
+def test_check_icon_url_rejects_non_image():
+    with pytest.raises(org.IconUrlError, match="画像ではない"):
+        org.check_icon_url("https://x.test/page", opener=_opener("text/html"))
+
+
+def test_check_icon_url_falls_back_to_get_when_head_rejected():
+    opener = _opener("image/webp", fail_head=True)
+    assert org.check_icon_url("https://x.test/a.webp", opener=opener)
+    assert [m for _, m in opener.calls] == ["HEAD", "GET"]
+
+
+def test_check_icon_url_rejects_unreachable():
+    def _boom(url: str, method: str, timeout: float) -> str:
+        raise TimeoutError("timed out")
+
+    with pytest.raises(org.IconUrlError, match="到達できない"):
+        org.check_icon_url("https://x.test/a.png", opener=_boom)

--- a/tests/test_org.py
+++ b/tests/test_org.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 from ryza import org
@@ -180,14 +182,18 @@ def test_apply_icon_overrides_passthrough_without_author():
 
 
 # ── URL 検証 ─────────────────────────────────────────────────────────────────
-def _opener(content_type: str, *, fail_head: bool = False):
+def _opener(content_type: str, *, length: str | None = "1024", fail_head: bool = False):
+    """``check_icon_url`` の I/O 差し替え口(小文字キーのヘッダ dict を返す)。"""
     calls: list[tuple[str, str]] = []
 
-    def _fake(url: str, method: str, timeout: float) -> str:
+    def _fake(url: str, method: str, timeout: float) -> dict[str, str]:
         calls.append((url, method))
         if fail_head and method == "HEAD":
             raise OSError("405 Method Not Allowed")
-        return content_type
+        headers = {"content-type": content_type}
+        if length is not None:
+            headers["content-length"] = length
+        return headers
 
     _fake.calls = calls  # type: ignore[attr-defined]
     return _fake
@@ -214,8 +220,36 @@ def test_check_icon_url_rejects_non_https(url):
 
 
 def test_check_icon_url_rejects_non_image():
-    with pytest.raises(org.IconUrlError, match="画像ではない"):
+    with pytest.raises(org.IconUrlError, match="対応していない画像形式"):
         org.check_icon_url("https://x.test/page", opener=_opener("text/html"))
+
+
+@pytest.mark.parametrize("content_type", list(org.ICON_ALLOWED_TYPES))
+def test_check_icon_url_accepts_each_allowed_type(content_type):
+    assert org.check_icon_url("https://x.test/a", opener=_opener(content_type))
+
+
+def test_check_icon_url_rejects_svg(caplog):
+    """SVG は script・外部参照を含みうるマークアップのため許可しない(C-8)。"""
+    with pytest.raises(org.IconUrlError, match="対応していない画像形式"):
+        org.check_icon_url("https://x.test/a.svg", opener=_opener("image/svg+xml"))
+
+
+def test_check_icon_url_rejects_oversized_image():
+    big = str(org.ICON_MAX_BYTES + 1)
+    with pytest.raises(org.IconUrlError, match="大きすぎる"):
+        org.check_icon_url("https://x.test/a.png", opener=_opener("image/png", length=big))
+
+
+def test_check_icon_url_accepts_exactly_max_size():
+    opener = _opener("image/png", length=str(org.ICON_MAX_BYTES))
+    assert org.check_icon_url("https://x.test/a.png", opener=opener)
+
+
+def test_check_icon_url_rejects_missing_content_length():
+    """サイズ未申告は拒否(ボディを実測しに行かない — SSRF 増幅・DoS を避ける)。"""
+    with pytest.raises(org.IconUrlError, match="Content-Length"):
+        org.check_icon_url("https://x.test/a.png", opener=_opener("image/png", length=None))
 
 
 def test_check_icon_url_falls_back_to_get_when_head_rejected():
@@ -225,8 +259,45 @@ def test_check_icon_url_falls_back_to_get_when_head_rejected():
 
 
 def test_check_icon_url_rejects_unreachable():
-    def _boom(url: str, method: str, timeout: float) -> str:
+    def _boom(url: str, method: str, timeout: float) -> dict[str, str]:
         raise TimeoutError("timed out")
 
     with pytest.raises(org.IconUrlError, match="到達できない"):
         org.check_icon_url("https://x.test/a.png", opener=_boom)
+
+
+# ── SSRF 緩和(独立役員審査 0020 C-6)────────────────────────────────────────
+@pytest.mark.parametrize(
+    "address", ["127.0.0.1", "10.1.2.3", "192.168.0.5", "169.254.169.254", "::1"]
+)
+def test_reject_internal_host_blocks_non_global_addresses(monkeypatch, address):
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    monkeypatch.setattr(
+        org.socket, "getaddrinfo",
+        lambda *a, **k: [(family, socket.SOCK_STREAM, 6, "", (address, 443))],
+    )
+    with pytest.raises(org.IconUrlError, match="内部アドレス"):
+        org._reject_internal_host("internal.test")
+
+
+def test_reject_internal_host_allows_public_address(monkeypatch):
+    monkeypatch.setattr(
+        org.socket, "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+    )
+    org._reject_internal_host("example.test")  # 例外が出なければ合格
+
+
+def test_reject_internal_host_rejects_unresolvable(monkeypatch):
+    def _boom(*a, **k):
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(org.socket, "getaddrinfo", _boom)
+    with pytest.raises(org.IconUrlError, match="解決できない"):
+        org._reject_internal_host("nx.test")
+
+
+def test_default_opener_does_not_follow_redirects():
+    """リダイレクト追従を無効化していること(3xx から内部宛へ誘導させない)。"""
+    handler = org._NoRedirect()
+    assert handler.redirect_request(None, None, 302, "Found", {}, "https://evil.test/") is None


### PR DESCRIPTION
## 概要

代表指示(2026-08-03)。キャラクターアイコンをダッシュボード(組織ページ)から再設定できるようにする。

- **migrations/0020**: ops.org_icon_overrides(現在値)+ org_icon_override_log(追記オンリー履歴 — トリガ+REVOKE で DB 側強制)
- **組織ページ編集 UI**: プレビュー+URL 入力+保存/初期値に戻す(IAP=代表1名なので追加認証なし)。書込は ryza_boardroom ロール・同一トランザクションで現在値+履歴
- **URL 検証**: https のみ・リダイレクト無効・private/link-local IP 拒否(SSRF 対策)・MIME 4種限定・5MB 上限
- **即反映**: Bot は配送時に上書きを解決(失敗時は台帳へフェイルオープン — 配送停止させない)。Webhook・朝刊・ダッシュボードに再デプロイ不要で反映
- deploy-dashboard.sh: BR ロールへ最小 GRANT(履歴表は INSERT のみ)+権限アサーション

## 承認・審査

- 保護領域該当: migrations/0020(schema)・ops/deploy-dashboard.sh(deploy_path)
- **独立役員審査**: 条件付き承認 → 必須2件(履歴書込の原子性・配送のフェイルオープン)+5件を是正済み。意見書: docs/reviews/0020-org-icon-overrides-independent-review.md。後続3件(protected_areas 登録・再ホスト化・内部キー分離)はリマインダー登録済み
- みなし承認(定款第3条 v0.4): #承認 通知と同時発効・代表はいつでも否認可

## 検証

901 テスト+ruff 通過(新規 50 件: 上書きマージ・URL 検証・原子性(autocommit 実測)・TRUNCATE/UPDATE/DELETE 拒否)

🤖 Generated with [Claude Code](https://claude.com/claude-code)