### PR TITLE
feat(universe): Jim curated 35銘柄の代表承認(mandates)

### DIFF
--- a/config/universe/jim-curated.yaml
+++ b/config/universe/jim-curated.yaml
@@ -59,8 +59,8 @@ manages_tags: [liquid_equity]
 
 # 承認記録(null の間は反映されない)。approved_at は ISO 日付、approved_by は
 # 'representative' 固定(起草者が自分で名乗れない — 審査 C-24)。
-approved_at: null
-approved_by: null
+approved_at: "2026-08-04"
+approved_by: "representative"
 
 # criterion + entries の正規化 sha256(内容と版の紐付け — 審査 C-25)。
 content_sha256: "69827e5059efb0215d91216cf7df292f6f055efe4478158cd040c7cf31045921"

--- a/tests/risk/test_classify.py
+++ b/tests/risk/test_classify.py
@@ -712,12 +712,14 @@ def test_loader_rejects_duplicate_symbols(tmp_path):
         load_curated_universe(path)
 
 
-def test_shipped_jim_universe_is_wellformed_but_unapproved():
-    """同梱の jim-curated.yaml は**未承認**なので読み込みが拒否される(fail-closed)。
+def test_shipped_jim_universe_is_wellformed_and_approved():
+    """同梱の jim-curated.yaml は代表承認済みとして読み込める(2026-08-04 承認)。
 
-    承認前に反映されないことがこのファイルの安全性の要であるため、状態そのものを固定する。
-    承認時にはこのテストを「読み込めること + 全エントリに rationale があること」へ
-    書き換える(承認がコード変更として残る)。
+    未承認時代の前身テストは「読み込み拒否」を固定していた(fail-closed の要)。
+    代表の明示承認(Discord 2026-08-04「売買候補は承認」・PR #99)により状態が変わった
+    ため、本テストは「承認済みの版が正しく読め、内容ハッシュ・承認記録が有効である」
+    ことを固定する。承認を取り消す場合は approved_at/approved_by を null に戻し、
+    このテストを前身の形に戻すこと(取消もコード変更として残る)。
     """
     path = _REPO_ROOT / "config" / "universe" / "jim-curated.yaml"
     raw = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -729,8 +731,10 @@ def test_shipped_jim_universe_is_wellformed_but_unapproved():
     assert raw["content_sha256"] == curated_content_digest(
         str(raw["criterion"]), list(raw["entries"])
     )
-    with pytest.raises(CuratedUniverseError, match="未承認"):
-        load_curated_universe(path)
+    universe = load_curated_universe(path)
+    assert len(universe.entries) == 35
+    assert str(raw["approved_by"]) == "representative"
+    assert str(raw["approved_at"]) == "2026-08-04"
 
 
 def test_universe_config_is_a_protected_area():


### PR DESCRIPTION
## 概要

Jim(紅莉栖)の売買候補リストの発効。**代表の明示承認**(Discord 2026-08-04「売買候補は承認」)に基づく承認記録の書き込み(approved_at/approved_by — 内容は #93 で審査済みの35銘柄・content_sha256 不変)。

- 発効後、次回 daily の分類で liquid_equity タグが付与され Jim のユニバースが有効化(それまでは従来どおり空)
- 保護領域該当: config/universe/**(mandates — #93 で登録)

## 承認

代表の明示承認(Discord 記録)。リスト内容の独立審査は #93 実施済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)