### PR TITLE
A-12 是正 F-6: リスク計測のポジション粒度是正(#121)

### DIFF
--- a/docs/reviews/f6-risk-position-granularity-review.md
+++ b/docs/reviews/f6-risk-position-granularity-review.md
@@ -1,0 +1,63 @@
+---
+review: f6-risk-position-granularity
+reviewed_sha: 6c0ecc5afd625477993502c7f89f7f3619d83668
+reviewer: independent-officer
+review_date: 2026-08-04
+verdict: approve
+---
+
+# リスク計測のポジション粒度是正(A-12 F-6・T-021・PR #133)— 独立役員審査
+
+- 審査日: 2026-08-04 / 審査者: 独立役員(非執行・批判専任。起草者・設計リードの選好は不知)
+- 対象: branch `f6-risk-position-granularity`(head 11db8e9)— `src/ryza/risk/daily.py`(`load_positions` 行単位化)・`src/ryza/risk/engine.py`(`RiskPosition.fm`・`guardrail_usage` 集計意味論・`es95` ネットゼロ除外)・`tests/risk/test_position_granularity.py`・指示書 `docs/tasks/T-021-risk-position-granularity.md`。**保護領域 `src/ryza/risk/`(リスクリミット — 定款第5条)**
+- 判定: **条件付き承認**(条件 1 件の是正をマージ前提とする)
+
+## 判定と理由
+
+F-6 の是正方向は正しく、指示書の集計意味論の裁定(グロス=行単位 Σ|value|・発行体集中=銘柄ネット後 abs・ES=銘柄符号付きネット)は金融的に整合し、ゲート側(`gate/compliance.py` の G-4/G-8 `_class_gross_post`/`_pod_gross_post` 行単位・G-3 `abs(post_fund_qty)×price`)とも一致することを独立に確認した。実装は指示書に忠実で、既存判定の不変はゴールデン(`engine_snapshot.json` — 本ブランチで無改変)が証明している。ただし **es95 のネットゼロ除外が 3 行以上の同一銘柄で機能しない反例**を発見したため、その是正を条件とする。
+
+**条件1(中・要是正 — es95 の銘柄ネットは Decimal 段で行うこと)**: `es95()` は行ごとに `float(pos.value / nav)` へ変換してから加算するため、同一銘柄 3 行以上(3 ポッド以上の両建て — `config/mandates/` には ben・jim・peter・stan の 4 ポッドが存在し到達可能)が経済的にネットゼロでも float 加算が厳密ゼロにならない。再現(乱択 20 万試行で 46,928 件=23.5% が非ゼロ残差): nav=4,608,515・+4,774,829・+529,379・−5,304,208 → 残差 2.22e-16。残差が残ると当該銘柄が `weights` に生き残り、(a) 共通観測日を縛って**偽の `no_common_days` 判定保留**(urgent レポート)、(b) 短系列なら `excluded`/`majority_excluded` の偽計上を招く — 指示書自身が掲げた「両建てが included や共通観測日の計算に混入して余計に判定保留を招くのを防ぐ」という目的が 3 行ケースで達成されない。付属テストは 2 行(`float(x)+float(−x)=0` は常に厳密)しか固定しておらず、この欠陥を検出できない。是正: `guardrail_usage` の issuer と同じ 2 段集計 — **銘柄ごとに Decimal で符号付き合算 → 非ゼロのみ `float(net/nav)` 化**。差は ≤1ulp でスナップショット(12 桁丸め)に影響しない。3 行ネットゼロのテストを追加すること。欠陥の起点は指示書の「weights は符号付き加算のまま」+後段 float フィルタという設計であり、実装エージェントの逸脱ではない。
+
+## 確認した事項
+
+1. **指示書の裁定の金融的妥当性**(独立検討): グロスを行単位で測るのは正しい — ポッド間の逆ポジは執行上の相殺ではなく、両レグとも解消コスト・ショートレグの調達実態を持つ。発行体集中は同一銘柄のロング/ショートが価格・発行体イベントの両面で厳密に相殺するためネット後 abs が正しい。ES は同一銘柄リターンが同一系列のため符号付きネットが厳密。三者は互いに矛盾せず、ゲートの G-3/G-4/G-8 とレポートが同じ数字の思想で動く
+2. **判定不変の証拠**: `tests/risk/engine_snapshot.json` は本ブランチで無改変(git log 確認)、`test_engine_invariance.py` 通過。スナップショットのケース集は銘柄 ID 重複を含まないため、今回の変更(重複時のみ挙動が変わる)で不変になるのは設計どおり
+3. **テスト実行**: `tests/risk/` 全 174 件通過(PG17 test DB)・`ruff check src/ryza/risk/ tests/risk/` 通過。新テスト 8 件は受け入れ基準の数値(両建て 2|q×price|/nav・部分相殺 |60×price| と 140×price・時価欠落 1 件・行単位返却・qty=0 除外)を固定値で当てている
+4. **副作用**: `daily.load_positions` の呼び出し元は `run_risk_daily` のみ。`risk/state.py`・embed・`limits_state` の metrics はポジション行を直接シリアライズせず、スキーマ・レポート形状に変化なし。`gate/orders.py` と `fm/base.py` の同名 `load_positions` は別物(PositionState)で無関係
+5. **fm 既定値 ""**: engine 側の既定は既存テスト・スナップショット構築の互換用で、daily 側は必ず実 fm を渡している。fm は集計に不使用(docstring どおり)
+6. **時価欠落×ネットゼロの合流**: 旧実装は HAVING で行ごと消え検出不能だった経路が、Exclusion(valuation/missing_price)1 件として銘柄単位で正しく浮上する(F-6 問題 2 の是正を確認)
+7. **手続**: 指示書が最初のコミット・コミットは日本語+指定トレーラ・ips.yaml 値のハードコードなし・LLM 非関与
+
+## 所見(条件以外)
+
+- **低**: `run_risk_daily` が `load_instrument_returns` に渡す `[p.instrument_id for p in positions]` は行単位化により重複を含む。`ANY(%s)` の意味論上は無害(結果同一)だが、重複排除しておくのが読み手に親切
+- **低**: 同一銘柄を複数ポッドが異なる `asset_class` で持つことをスキーマは禁じていない(PK は book×fm×instrument)。`by_class` は行の申告クラスに計上・issuer/ES は銘柄でネットという現挙動はデータを信じる前提では正しいが、分類不整合の検出は T-015 系の分類 completeness 側の課題として既知
+- **情報**: `issuer_concentration` は instrument 単位であり発行体エンティティ単位ではない(同一発行体の別商品は合算されない)。ゲート G-3 と同スコープの既存仕様で、本変更の対象外
+- **情報**: ネットゼロ銘柄の時価が欠落した場合、その両建てエクスポージャーはグロスにも入らない(評価除外)。Exclusion で開示され、発注時はゲートが fail-closed で block するため、既存の fail-safe 方針と整合
+
+## サマリ(200字以内)
+
+F-6 是正の方向・測度別集計意味論・ゲートとの整合・スナップショット不変を確認し条件付き承認。唯一の条件: es95 の銘柄ネットを float 加算でなく Decimal 段で行うこと。3 ポッド以上の両建てで float 残差(再現率 23.5%)がネットゼロ除外を破り、偽の判定保留を招く。是正は 2 段集計への小変更でスナップショット影響なし。
+
+## 第2ラウンド(条件解消検証)
+
+- 審査日: 2026-08-04 / 対象: 是正コミット 6c0ecc5afd625477993502c7f89f7f3619d83668(branch head — worktree で `git rev-parse HEAD` 一致を確認)/ 前回 reviewed_sha 11db8e9 との差分全体を精読
+- 判定: **承認(approve)** — 条件1 は解消。新規問題なし
+
+### 検証結果(全て実測)
+
+1. **差分の範囲**: `git diff 11db8e9..6c0ecc5` は 3 ファイルのみ(`src/ryza/risk/engine.py` +19/−7 相当・`docs/tasks/T-021-risk-position-granularity.md` §4・`tests/risk/test_position_granularity.py` +26)。条件対応以外の紛れ込みなし
+2. **実装の正しさ**: `es95` は instrument_id ごとに Decimal で符号付き合算(`signed: dict[int, Decimal]`)→ 厳密ゼロの銘柄を落とす → `float(v / nav)` で weights 化。条件1 の指定どおりの 2 段集計。行単位 `pos.value != 0` ガードは残るが Decimal 加算への寄与ゼロのため無害(最適化として整合)。ゼロ落とし後の included/excluded/共通観測日ロジックは無変更で、weights のキー集合が正しくなる以外の影響なし。`nav <= 0` は合算前に早期 return(既存)。Decimal 合算は金額スケールで文脈精度 28 桁内に収まり厳密
+3. **新テストが旧実装で fail することの確認**: `git checkout 11db8e9 -- src/ryza/risk/engine.py` で旧 es95 に戻し `test_es95_three_row_net_zero_is_dropped_without_float_residual` を実行 → **fail**(`n_obs=0`・`deferral_reason='no_common_days'` — 前回指摘の偽保留がそのまま再現)。`git checkout 6c0ecc5 -- src/ryza/risk/engine.py` で復元し `git status` クリーンを確認
+4. **乱択再検証**: 前回と同型の 3〜4 行ネットゼロ乱択 **20,000 試行**(nav ¥1M〜100M・値 ±10M・4 fm 混在・観測日が交わらない別銘柄を併置)を新実装に対して実行 → **残差ゼロ 20,000/20,000・偽保留 0 件・偽 excluded 0 件**。同一試行集合で旧方式(行ごと float 化→加算)なら 8,642 件(43.2%)が非ゼロ残差(試行集合が欠陥を踏む能力を持つことの確認)
+5. **テストスイート**: `tests/risk/` **175 件全通過**(前回 174 → 新テスト +1)。`ruff check src/ryza/risk/ tests/risk/` 通過
+6. **スナップショット不変**: `tests/risk/engine_snapshot.json` は差分範囲で無変更(git diff 空・最終変更コミットは本ブランチ以前の 63e12cb)。`test_engine_invariance.py` は 175 件に含まれ通過 — `float(Σ Decimal / nav)` と旧 `Σ float(v/nav)` の差 ≤1ulp が 12 桁丸めに現れないという前回の見立てどおり
+7. **指示書の是正**: T-021 §4 が Decimal 段ネットを規定し「float 加算で合算してはならない」と根拠(3行以上・残差 ~1e-16・偽保留)込みで明記。設計欠陥の起点が指示書側にあった点も文書に反映された
+
+### 所見(判定に影響しない)
+
+- **情報**: 新テストの 3 行目が `fm="pam"` だが、実在ポッドは ben・jim・peter・stan(`config/mandates/`)。fm は es95 の集計に不使用(engine docstring どおり)のため挙動に影響なし。将来リネームの機会があれば実在名に揃えるのが読み手に親切
+
+### サマリ(第2ラウンド)
+
+条件1 は解消。Decimal 段ネットは指定どおり実装され、旧実装で fail する決定的テストが追加され、乱択 2 万試行で残差・偽保留ともゼロを実測。スナップショット不変・175 件通過・ruff 通過・差分に紛れ込みなし。残課題なし(fm="pam" は情報レベルのみ)。**最終判定: approve**。

--- a/docs/tasks/T-021-risk-position-granularity.md
+++ b/docs/tasks/T-021-risk-position-granularity.md
@@ -1,0 +1,68 @@
+# T-021: リスク計測のポジション粒度是正(ポッド間ネットの解消 — A-12 是正 F-6・Issue #121)
+
+- 起草: 2026-08-04 設計リード / 前提: T-015 統合済み main に対して作業
+- 前提知識: CLAUDE.md、docs/reviews/t014-design-decisions.md 項目3(グロス計算の行単位化)、src/ryza/risk/{engine,daily}.py、migrations/0014(trading.positions)
+- **保護領域**(リスクリミット)。統合は設計リードが独立役員審査+みなし承認手続で行う
+- 本仕様書自体を実装ブランチの最初のコミットとして `docs/tasks/T-021-risk-position-granularity.md` に含めること
+
+## 問題(F-6)
+
+`load_positions`(src/ryza/risk/daily.py:126-198)は `GROUP BY p.instrument_id, p.asset_class HAVING sum(p.qty) <> 0` で**ポッド(fm)間をネット**してから時価評価する。`trading.positions` の PK は (book_id, fm, instrument_id)(0014:94-104)で qty は符号付き。ポッド A が +100、ポッド B が -100 を持つと、リスクエンジンには**保有ゼロ**として渡り:
+
+1. **グロスレバ・資産クラスグロスが過小計上**される(gross_leverage / single_asset_class_gross は本来 Σ|行| で測るべき — ゲート側 G-4/G-8 は t014 設計判断3 で行単位 Σ|qty|×時価に是正済み。リスクレポート側だけポッド間ネットが残った)
+2. ネットゼロ銘柄の時価欠落が**検出されない**(HAVING で行ごと消えるため Exclusion にも notes にも出ない)
+
+## 是正方針(設計リード裁定 — 測度ごとに集計意味論を分ける)
+
+ポジションは**行単位(fm × instrument)**でエンジンへ渡し、ネットするかどうかは**各測度の意味論に従って測度側で決める**:
+
+| 測度 | 集計 | 理由 |
+|---|---|---|
+| gross_leverage / single_asset_class_gross | **行単位 Σ\|value\|**(ネットしない) | 建玉の総量を測る。ポッド間の相殺は執行上の相殺ではない(t014 設計判断3 と同じ理屈) |
+| issuer_concentration | **銘柄単位でネット後 abs** | ゲートのファンド集中(compliance.py の abs(post_fund_qty))と同じ意味論。同一銘柄の両建ては発行体リスクとしては相殺される |
+| ES(es95) | **銘柄単位でネット**(現行の weights 集計を維持) | 同一銘柄の逆ポジションの P&L は厳密に相殺する。engine.py:266-271 の weights は既に instrument_id ごとに符号付き加算しており、行単位入力にすればそのまま正しくネットされる |
+
+## 実装
+
+### 1. `daily.load_positions` — 行単位化
+
+- SQL を `SELECT p.fm, p.instrument_id, p.asset_class, p.qty FROM trading.positions p WHERE p.book_id = %s AND p.qty <> 0` に変更(GROUP BY 廃止。行内 qty=0 のみ落とす — ポッド内の消滅ポジション)
+- 時価・乗数の取得は現行どおり銘柄単位(ids は重複排除すること)
+- **時価欠落の Exclusion / notes は銘柄単位で重複排除**(同一銘柄を複数ポッドが持つ場合に2重に出さない)
+- docstring の「全ポッド合算・銘柄単位」を実態に合わせて更新
+
+### 2. `engine.RiskPosition` — fm フィールド追加
+
+```python
+@dataclass(frozen=True)
+class RiskPosition:
+    instrument_id: int
+    asset_class: str
+    value: Decimal  # 符号付き JPY 時価総額(行=fm×instrument 単位)
+    fm: str = ""    # 保有ポッド。集計はしないが由来の開示・デバッグ用
+```
+
+既存テストの構築箇所が壊れないようデフォルト値を持たせてよい(ただし daily 側は必ず実 fm を渡す)。
+
+### 3. `engine.guardrail_usage` — issuer のみネット化
+
+- `by_issuer` を2段集計に変更: まず instrument_id ごとに**符号付き** value を合算 → その後 abs
+- `by_class` / `gross` は現行の行単位 Σ|value| のまま(入力が行単位になることで自動的にグロス計上になる — これが是正の本体)
+- docstring に測度ごとの集計意味論(上表)を明記
+
+### 4. `engine.es95` — ネットゼロの後処理
+
+- weights 集計後、**ネット結果が 0 の銘柄を weights から落とす**(現行は行単位の `pos.value != 0` ガードのみで、合算後ゼロが `included`/除外判定・共通観測日の計算に混入し得る)
+- それ以外のロジックは変更しない
+
+## テスト(tests/risk/)
+
+- 両建てシナリオ: 同一銘柄をポッド A +q・ポッド B -q で保有 → gross_leverage と single_asset_class_gross は 2|q×price|/nav、issuer_concentration は 0、es95 の weights から当該銘柄が消える(ネットゼロ)
+- 部分相殺: +100/-40 → issuer は |60×price|、gross は 140×price
+- 時価欠落×複数ポッド: 同一銘柄を2ポッドが保有し時価欠落 → Exclusion / notes は**1件**
+- load_positions が fm 単位の行を返すこと(合算しないこと)の DB テスト
+- **snapshot**: tests/risk/test_engine_invariance.py と engine_snapshot.json は保護されたリグレッション固定。両建てが無い入力では結果が不変であること(不変が期待値)。もし snapshot 更新が必要になった場合は、差分の数値的理由を PR 本文で説明すること(黙って更新しない)
+
+## 受け入れ基準
+
+全テスト+ruff 通過 / 両建てシナリオで上表どおりの数値(手計算固定値で検証)/ 両建て無しの既存入力で全測度の結果不変 / ips.yaml 値のハードコードなし / LLM 非関与 / コミットは日本語+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>、push しない(統合は設計リードが行う)

--- a/docs/tasks/T-021-risk-position-granularity.md
+++ b/docs/tasks/T-021-risk-position-granularity.md
@@ -52,7 +52,8 @@ class RiskPosition:
 
 ### 4. `engine.es95` — ネットゼロの後処理
 
-- weights 集計後、**ネット結果が 0 の銘柄を weights から落とす**(現行は行単位の `pos.value != 0` ガードのみで、合算後ゼロが `included`/除外判定・共通観測日の計算に混入し得る)
+- 銘柄合算は **Decimal 段で行い、合算後に float 化**する: instrument_id ごとに `Decimal` の value を符号付きで合算 → 合算結果が 0 の銘柄を落とす → 残りを `float(v / nav)` で weights に変換
+- float 加算で合算してはならない。同一銘柄3行以上(4ポッド構成で到達可能)のネットゼロは float では残差 ~1e-16 が残り、偽の判定保留(no_common_days)を招く(独立役員審査 2026-08-04 条件1で実測 — 乱択20万試行中23.5%で再現)
 - それ以外のロジックは変更しない
 
 ## テスト(tests/risk/)

--- a/src/ryza/risk/daily.py
+++ b/src/ryza/risk/daily.py
@@ -126,12 +126,21 @@ def load_nav_series(conn: psycopg.Connection, book_id: str) -> NavSeries:
 def load_positions(
     conn: psycopg.Connection, book_id: str, *, as_of: datetime
 ) -> tuple[list[engine.RiskPosition], list[str], list[engine.Exclusion]]:
-    """帳簿の現在ポジション(全ポッド合算・銘柄単位)を時価評価する。
+    """帳簿の現在ポジションを**行=fm×instrument 単位**で時価評価する(A-12 F-6・T-021)。
+
+    以前は ``GROUP BY (instrument_id, asset_class) HAVING sum(qty) <> 0`` でポッド間を
+    ネットしてから時価評価していたが、これでは両建て(+q / −q)が保有ゼロとして
+    リスクエンジンに渡り、グロスレバ・資産クラスグロスが過小計上され、ネットゼロ
+    銘柄の時価欠落も検出されなかった。是正: 行(``fm``+``instrument_id``)単位で
+    そのまま返し、ネットするかどうかは各測度の意味論に従って測度側で決める
+    (``engine.guardrail_usage`` / ``engine.es95`` の docstring 参照)。
 
     時価は ``market.bars``(1d)の **as_of 以前の**最新終値×現行銘柄の乗数
     (point-in-time — 不変原則4。過去日付での再実行に未来バーを混入させない)。
     時価の無い銘柄は評価から除外し notes に明記する(fail-safe: 落とさず測れる
     範囲で測り、欠測は隠さない。発注時の欠測はゲート側が fail-closed で block する)。
+    **時価欠落の Exclusion / notes は銘柄単位で重複排除する**(同一銘柄を複数ポッドが
+    保有している場合に 2 重に出さない — T-021)。
 
     返り値の 3 つ目は同じ除外の**機械可読版**(``engine.Exclusion``)。ES とガード
     レールの採用値がどの銘柄を含まないかを、日本語の notes ではなく構造で残す
@@ -140,18 +149,18 @@ def load_positions(
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT p.instrument_id, p.asset_class, sum(p.qty)
+            SELECT p.fm, p.instrument_id, p.asset_class, p.qty
             FROM trading.positions p
-            WHERE p.book_id = %s
-            GROUP BY p.instrument_id, p.asset_class
-            HAVING sum(p.qty) <> 0
+            WHERE p.book_id = %s AND p.qty <> 0
             """,
             (book_id,),
         )
         rows = cur.fetchall()
         if not rows:
             return [], [], []
-        ids = [r[0] for r in rows]
+        # 時価・乗数は銘柄単位で引く(同じ銘柄を複数ポッドが持つケースに備えて
+        # 重複排除する — T-021)。
+        ids = sorted({r[1] for r in rows})
         cur.execute(
             """
             SELECT DISTINCT ON (instrument_id) instrument_id, close
@@ -177,22 +186,28 @@ def load_positions(
     positions: list[engine.RiskPosition] = []
     notes: list[str] = []
     exclusions: list[engine.Exclusion] = []
-    for instrument_id, asset_class, qty in rows:
+    seen_missing: set[int] = set()  # 時価欠落の重複出力を抑止(T-021)
+    for fm, instrument_id, asset_class, qty in rows:
         price = prices.get(instrument_id)
         if price is None:
-            notes.append(f"時価欠落のため評価除外: instrument {instrument_id}")
-            exclusions.append(
-                engine.Exclusion(
-                    instrument_id=instrument_id,
-                    measure=engine.MEASURE_VALUATION,
-                    reason=engine.REASON_MISSING_PRICE,
+            if instrument_id not in seen_missing:
+                seen_missing.add(instrument_id)
+                notes.append(f"時価欠落のため評価除外: instrument {instrument_id}")
+                exclusions.append(
+                    engine.Exclusion(
+                        instrument_id=instrument_id,
+                        measure=engine.MEASURE_VALUATION,
+                        reason=engine.REASON_MISSING_PRICE,
+                    )
                 )
-            )
             continue
         value = Decimal(qty) * price * multipliers.get(instrument_id, Decimal(1))
         positions.append(
             engine.RiskPosition(
-                instrument_id=instrument_id, asset_class=asset_class, value=value
+                instrument_id=instrument_id,
+                asset_class=asset_class,
+                value=value,
+                fm=fm,
             )
         )
     return positions, notes, exclusions

--- a/src/ryza/risk/engine.py
+++ b/src/ryza/risk/engine.py
@@ -83,11 +83,20 @@ class NavPoint:
 
 @dataclass(frozen=True)
 class RiskPosition:
-    """ポジション評価額1件(ES・ガードレール入力)。value は符号付き JPY 時価総額。"""
+    """ポジション評価額1件(ES・ガードレール入力)。
+
+    行=**fm × instrument** 単位で受け取る(A-12 是正 F-6・T-021)。ポッド間のネットは
+    測度の意味論に従って**測度側**で決める(``guardrail_usage`` の docstring 参照)。
+    グロス測度(gross_leverage / single_asset_class_gross)は行単位 Σ|value| で測り、
+    発行体集中度と ES は同一銘柄を符号付きで合算してから abs / weights に載せる。
+    ``value`` は符号付き JPY 時価総額(負=ショート・行単位)。``fm`` は由来ポッドで、
+    集計には使わないがレポートと監査のトレーサビリティのために保持する。
+    """
 
     instrument_id: int
     asset_class: str
     value: Decimal
+    fm: str = ""  # 保有ポッド(A-12 F-6): 集計はしないが由来の開示・デバッグ用
 
 
 @dataclass(frozen=True)
@@ -263,12 +272,18 @@ def es95(
     """
     if nav <= 0:
         return ESResult(None, None, 0.0, 0)
+    # 銘柄単位でネット(行=fm×instrument 入力を許容 — A-12 F-6・T-021)。ES は同一銘柄の
+    # 逆ポジション P&L が厳密に相殺するため、weights は符号付き加算のまま。
     weights: dict[int, float] = {}
     for pos in positions:
         if pos.value != 0:
             weights[pos.instrument_id] = weights.get(pos.instrument_id, 0.0) + float(
                 pos.value / nav
             )
+    # ネット後に厳密ゼロになった銘柄は落とす(両建てが `included` や共通観測日の計算に
+    # 混入して余計に判定保留を招くのを防ぐ — T-021)。行単位の pos.value != 0 ガードだけ
+    # では合算後ゼロを掬えなかった。
+    weights = {i: w for i, w in weights.items() if w != 0.0}
     if not weights:
         return ESResult(None, None, 0.0, 0)
 
@@ -432,21 +447,36 @@ def guardrail_usage(
 ) -> dict[str, dict[str, float | str | None]]:
     """ガードレール消費率(現在値/上限 — 日次リスクレポート用。判定はゲートの管轄)。
 
-    返り値は ``{名前: {value, limit, usage}}``。usage は上限に対する消費率(0..∞)。
-    現金下限のみ「下限」なので usage = 下限/現在値(現在値が下限に近いほど 1 に近づく)。
+    **測度ごとに集計の意味論が違う**(A-12 F-6・T-021):
+
+    - ``gross_leverage`` / ``single_asset_class_gross``: **行単位 Σ|value|**(ネット
+      しない)。建玉の総量を測る指標なのでポッド間の相殺は執行上の相殺ではなく、
+      両建ては両建てのまま計上する(t014 設計判断3 と同じ理屈 — ゲート G-4/G-8 の
+      グロス計算と整合)
+    - ``issuer_concentration``: **銘柄単位で符号付き合算 → abs**。同一銘柄の両建ては
+      発行体リスクとしては相殺される(compliance.py の abs(post_fund_qty) と同じ
+      意味論)
+    - ``cash_floor``: 現金下限は下限なので usage = 下限/現在値(下限に近いほど 1)
+
+    返り値は ``{名前: {value, limit, usage}}``。
     """
     if nav <= 0:
         return {}
     hl, gr = ips.hard_limits, ips.guardrails
-    by_issuer: dict[int, Decimal] = {}
+    # issuer は **銘柄単位でネット後 abs**(2段集計 — T-021)。まず符号付きで合算し、
+    # そのうえで絶対値を取る。両建ては 0 になる(発行体リスクとしては正しい)。
+    signed_by_issuer: dict[int, Decimal] = {}
     by_class: dict[str, Decimal] = {}
     gross = Decimal(0)
     for pos in positions:
-        by_issuer[pos.instrument_id] = by_issuer.get(pos.instrument_id, Decimal(0)) + abs(
-            pos.value
+        signed_by_issuer[pos.instrument_id] = (
+            signed_by_issuer.get(pos.instrument_id, Decimal(0)) + pos.value
         )
+        # class / gross は行単位 Σ|value|(入力が行単位になったことで自動的にグロス
+        # 計上になる — F-6 是正の本体)。
         by_class[pos.asset_class] = by_class.get(pos.asset_class, Decimal(0)) + abs(pos.value)
         gross += abs(pos.value)
+    by_issuer = {i: abs(v) for i, v in signed_by_issuer.items()}
 
     top_issuer = max(by_issuer.values(), default=Decimal(0))
     top_class_name, top_class_value = max(

--- a/src/ryza/risk/engine.py
+++ b/src/ryza/risk/engine.py
@@ -273,17 +273,22 @@ def es95(
     if nav <= 0:
         return ESResult(None, None, 0.0, 0)
     # 銘柄単位でネット(行=fm×instrument 入力を許容 — A-12 F-6・T-021)。ES は同一銘柄の
-    # 逆ポジション P&L が厳密に相殺するため、weights は符号付き加算のまま。
-    weights: dict[int, float] = {}
+    # 逆ポジション P&L が厳密に相殺するため、符号付き合算でネットする。
+    # 合算は **Decimal 段**で行い、ネット後に float 化する(独立役員審査 2026-08-04
+    # 条件1): 行ごとに float 化してから加算すると同一銘柄3行以上のネットゼロが
+    # 丸め残差(~1e-16)で消えず、偽の判定保留(no_common_days)を招く。
+    signed: dict[int, Decimal] = {}
     for pos in positions:
         if pos.value != 0:
-            weights[pos.instrument_id] = weights.get(pos.instrument_id, 0.0) + float(
-                pos.value / nav
+            signed[pos.instrument_id] = (
+                signed.get(pos.instrument_id, Decimal(0)) + pos.value
             )
     # ネット後に厳密ゼロになった銘柄は落とす(両建てが `included` や共通観測日の計算に
-    # 混入して余計に判定保留を招くのを防ぐ — T-021)。行単位の pos.value != 0 ガードだけ
-    # では合算後ゼロを掬えなかった。
-    weights = {i: w for i, w in weights.items() if w != 0.0}
+    # 混入して余計に判定保留を招くのを防ぐ — T-021)。Decimal 同士の合算なので
+    # ゼロ判定は厳密に決まる。
+    weights: dict[int, float] = {
+        i: float(v / nav) for i, v in signed.items() if v != 0
+    }
     if not weights:
         return ESResult(None, None, 0.0, 0)
 

--- a/tests/risk/test_position_granularity.py
+++ b/tests/risk/test_position_granularity.py
@@ -107,6 +107,32 @@ def test_es95_drops_net_zero_instrument_after_weight_aggregation():
     assert not result.deferred
 
 
+def test_es95_three_row_net_zero_is_dropped_without_float_residual():
+    """3行ネットゼロ(4ポッド構成で到達可能)でも weights から確実に落ちる。
+
+    独立役員審査 2026-08-04 条件1: float 段で合算すると weights が
+    0.1 + 0.2 − 0.3 = 5.55e-17 型の残差を残し、ネットゼロ銘柄が included に
+    生き残って偽の判定保留(no_common_days)を招く(乱択20万試行中23.5%で再現)。
+    Decimal 段で銘柄合算→float 化すること(T-021 §4)。値は nav=10M に対して
+    weights がちょうど 0.1 / 0.2 / −0.3 になるよう選び、残差を決定的に再現する。
+    """
+    nav = Decimal(10_000_000)
+    positions = [
+        RiskPosition(1, "equity_jp", Decimal(1_000_000), fm="ben"),   # w=0.1
+        RiskPosition(1, "equity_jp", Decimal(2_000_000), fm="jim"),   # w=0.2
+        RiskPosition(1, "equity_jp", Decimal(-3_000_000), fm="pam"),  # w=-0.3
+        RiskPosition(2, "equity_us", Decimal(5_000_000), fm="ben"),
+    ]
+    # 銘柄 1 と 2 は観測日が交わらない。銘柄 1 が weights に残ると
+    # common_days が空になり no_common_days で保留してしまう。
+    rets = _returns_map(1, [0.0] * 30, start=date(2029, 1, 1))
+    rets.update(_returns_map(2, [0.0] * 30, start=date(2029, 6, 1)))
+    result = es95(positions, nav, rets, min_obs=20)
+    assert 1 not in result.excluded
+    assert result.n_obs == 30
+    assert not result.deferred
+
+
 def test_es95_all_positions_net_to_zero_returns_flat_zero():
     """全銘柄が両建てで消えるとポジション無しと同じ(判定保留にしない)。"""
     positions = [

--- a/tests/risk/test_position_granularity.py
+++ b/tests/risk/test_position_granularity.py
@@ -1,0 +1,221 @@
+"""ポジション粒度是正(A-12 F-6・T-021)のテスト。
+
+- ``guardrail_usage`` の集計意味論(グロス系は行単位 Σ|value|、issuer は銘柄単位でネット後 abs)
+- ``es95`` のネットゼロ銘柄除外(両建てが weights に残り判定保留を招かないこと)
+- ``load_positions`` の行単位返却(GROUP BY 廃止)と時価欠落の**銘柄単位**重複排除
+
+判定境界は config/ips.yaml の実値に対して当てる(保護領域のリグレッション検知)。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from ryza.risk.daily import load_positions
+from ryza.risk.engine import (
+    RiskPosition,
+    es95,
+    guardrail_usage,
+)
+
+_AS_OF = datetime(2030, 2, 1, 0, 0, tzinfo=UTC)
+
+
+def _returns_map(instrument_id, values, *, start=date(2029, 1, 1)):
+    from datetime import timedelta
+
+    return {instrument_id: {start + timedelta(days=i): v for i, v in enumerate(values)}}
+
+
+# ── guardrail_usage: 測度ごとの集計意味論 ─────────────────────────────────────
+def test_guardrail_usage_gross_measures_are_row_wise_on_offsetting_pods(ips):
+    """両建て(ポッド A +q / ポッド B −q): グロス系は 2|q×price|/nav、issuer は 0。
+
+    ネット後 abs の旧実装ではグロスも issuer も 0 になり過小計上だった(A-12 F-6)。
+    """
+    price = Decimal(1000)
+    qty = Decimal(100)
+    value = qty * price  # 100_000
+    positions = [
+        RiskPosition(1, "equity_jp", value, fm="ben"),
+        RiskPosition(1, "equity_jp", -value, fm="jim"),
+    ]
+    nav = Decimal(1_000_000)
+    usage = guardrail_usage(positions, nav, cash=Decimal(200_000), ips=ips)
+    # gross: 行単位 Σ|value| = 200_000 → 0.2x
+    assert usage["gross_leverage"]["value"] == 0.2
+    # 資産クラスグロスも同じ理屈(equity_jp = 200_000)
+    assert usage["single_asset_class_gross"]["value"] == 0.2
+    assert usage["single_asset_class_gross"]["class"] == "equity_jp"
+    # issuer: 銘柄単位でネット後 abs → 0(発行体リスクとしては相殺)
+    assert usage["issuer_concentration"]["value"] == 0.0
+
+
+def test_guardrail_usage_partial_offset_nets_issuer_and_gross_row_wise(ips):
+    """部分相殺(+100 / -40): issuer=|60×price|/nav、gross=140×price/nav。"""
+    price = Decimal(1000)
+    positions = [
+        RiskPosition(1, "equity_jp", Decimal(100) * price, fm="ben"),   # +100_000
+        RiskPosition(1, "equity_jp", Decimal(-40) * price, fm="jim"),   # -40_000
+    ]
+    nav = Decimal(1_000_000)
+    usage = guardrail_usage(positions, nav, cash=None, ips=ips)
+    assert usage["issuer_concentration"]["value"] == float(Decimal(60_000) / nav)
+    assert usage["gross_leverage"]["value"] == float(Decimal(140_000) / nav)
+    assert usage["single_asset_class_gross"]["value"] == float(Decimal(140_000) / nav)
+
+
+def test_guardrail_usage_issuer_uses_abs_after_signed_sum_across_instruments(ips):
+    """同一銘柄で符号付き合算した後に abs をとる(異銘柄は独立)。"""
+    price = Decimal(1000)
+    positions = [
+        RiskPosition(1, "equity_jp", Decimal(100) * price, fm="ben"),   # +100_000
+        RiskPosition(1, "equity_jp", Decimal(-100) * price, fm="jim"),  # -100_000 → net 0
+        RiskPosition(2, "equity_us", Decimal(50) * price, fm="ben"),    # +50_000
+    ]
+    nav = Decimal(1_000_000)
+    usage = guardrail_usage(positions, nav, cash=None, ips=ips)
+    # issuer top は銘柄 2(銘柄 1 は両建てで 0)
+    assert usage["issuer_concentration"]["value"] == float(Decimal(50_000) / nav)
+    # gross: 100_000 + 100_000 + 50_000 = 250_000
+    assert usage["gross_leverage"]["value"] == float(Decimal(250_000) / nav)
+
+
+# ── es95: ネット結果ゼロの銘柄を weights から落とす ────────────────────────────
+def test_es95_drops_net_zero_instrument_after_weight_aggregation():
+    """両建て(+q / -q)は weights 合算後 0 になり、共通観測日の計算に混入しない。
+
+    落とさないと `included` に残り、その銘柄の観測日で `common_days` が縛られて
+    余計に判定保留(no_common_days)が出る可能性がある。行=fm×instrument 入力を
+    許容する上で必須の後処理(T-021)。
+    """
+    positions = [
+        RiskPosition(1, "equity_jp", Decimal(5_000_000), fm="ben"),
+        RiskPosition(1, "equity_jp", Decimal(-5_000_000), fm="jim"),
+        RiskPosition(2, "equity_us", Decimal(5_000_000), fm="ben"),
+    ]
+    # 銘柄 1 と 2 は日付ずれ(共通観測日ゼロ)。銘柄 1 が weights から落ちれば
+    # 銘柄 2 単独で測定が成立する。
+    rets = _returns_map(1, [0.0] * 30, start=date(2029, 1, 1))
+    rets.update(_returns_map(2, [0.0] * 30, start=date(2029, 6, 1)))
+    result = es95(positions, Decimal(10_000_000), rets, min_obs=20)
+    # 銘柄 1 は weights から落ちる → 除外にも入らない(そもそも測定候補ですらない)
+    assert 1 not in result.excluded
+    # 銘柄 2 単独で 30 観測 → 測定成立(保留しない)
+    assert result.n_obs == 30
+    assert not result.deferred
+
+
+def test_es95_all_positions_net_to_zero_returns_flat_zero():
+    """全銘柄が両建てで消えるとポジション無しと同じ(判定保留にしない)。"""
+    positions = [
+        RiskPosition(1, "equity_jp", Decimal(5_000_000), fm="ben"),
+        RiskPosition(1, "equity_jp", Decimal(-5_000_000), fm="jim"),
+    ]
+    rets = _returns_map(1, [0.0] * 30)
+    result = es95(positions, Decimal(10_000_000), rets, min_obs=20)
+    assert result.adopted == 0.0
+    assert result.n_obs == 0
+    assert not result.deferred  # 「保有無し」と等価 — 保留ではない
+
+
+# ── load_positions: 行単位返却+時価欠落の銘柄単位重複排除 ─────────────────────
+def _seed_book(conn, book="DEMO_FUND"):
+    """テスト用の帳簿と評価勘定を用意する(既存の DEMO_FUND を使う想定だが念のため)。"""
+    # DEMO_FUND は seed で作成済み(migrations/0006 系)。ここは何もしない。
+    return book
+
+
+def _seed_instrument(conn, symbol="MULTIPOD.T", asset_class="equity") -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO market.instruments (symbol, asset_class, venue, currency, valid_from)
+            VALUES (%s, %s, 'TSE', 'JPY', now())
+            RETURNING instrument_id
+            """,
+            (symbol, asset_class),
+        )
+        return cur.fetchone()[0]
+
+
+def _seed_bar(conn, instrument_id, close, *, run_id, ts=None):
+    ts = ts or datetime(2030, 1, 30, 6, tzinfo=UTC)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO market.bars
+                (instrument_id, ts, timeframe, close, source, as_of, run_id)
+            VALUES (%s, %s, '1d', %s, 'test', %s, %s)
+            """,
+            (instrument_id, ts, Decimal(str(close)), ts, run_id),
+        )
+
+
+def _seed_position(conn, instrument_id, fm, qty, *, run_id,
+                   book="DEMO_FUND", asset_class="equity_jp"):
+    """複数 fm(PK 一部)で同じ instrument を保有できる。"""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO trading.positions
+                (book_id, fm, instrument_id, asset_class, qty, avg_cost, run_id)
+            VALUES (%s, %s, %s, %s, %s, 1000, %s)
+            """,
+            (book, fm, instrument_id, asset_class, qty, run_id),
+        )
+
+
+def test_load_positions_returns_rows_per_fm_without_aggregation(conn, run_id):
+    """同一銘柄をポッド A +100・ポッド B −100 で保有 → **2 行**返る(ネットしない)。"""
+    _seed_book(conn)
+    inst = _seed_instrument(conn)
+    _seed_bar(conn, inst, 1000, run_id=run_id)
+    _seed_position(conn, inst, "ben", 100, run_id=run_id)
+    _seed_position(conn, inst, "jim", -100, run_id=run_id)
+
+    positions, notes, exclusions = load_positions(conn, "DEMO_FUND", as_of=_AS_OF)
+    # 対象銘柄の行を抜き出す(seed の他銘柄には触れない)
+    rows = [p for p in positions if p.instrument_id == inst]
+    assert len(rows) == 2  # ネットせず 2 行のまま
+    fms = sorted(p.fm for p in rows)
+    assert fms == ["ben", "jim"]
+    # 符号もそのまま保持されている(fm × instrument の粒度で符号付き value)
+    values = sorted(int(p.value) for p in rows)
+    assert values == [-100_000, 100_000]
+    assert notes == []
+    assert exclusions == []
+
+
+def test_load_positions_deduplicates_missing_price_exclusion_across_pods(conn, run_id):
+    """同一銘柄を 2 ポッドが保有し時価欠落 → Exclusion / notes は 1 件だけ(T-021)。"""
+    _seed_book(conn)
+    inst = _seed_instrument(conn, symbol="NOPRICE_MULTI.T")
+    # バーは入れない = 時価欠落
+    _seed_position(conn, inst, "ben", 100, run_id=run_id)
+    _seed_position(conn, inst, "jim", 50, run_id=run_id)
+
+    positions, notes, exclusions = load_positions(conn, "DEMO_FUND", as_of=_AS_OF)
+    # 対象銘柄は評価から外れる(全ポッド分)
+    assert not any(p.instrument_id == inst for p in positions)
+    # notes / exclusions は当該銘柄について 1 件のみ
+    my_notes = [n for n in notes if f"instrument {inst}" in n]
+    my_excl = [e for e in exclusions if e.instrument_id == inst]
+    assert len(my_notes) == 1
+    assert len(my_excl) == 1
+    assert my_excl[0].measure == "valuation"
+    assert my_excl[0].reason == "missing_price"
+
+
+def test_load_positions_skips_zero_qty_rows(conn, run_id):
+    """行内で qty=0 のポジション(消滅ポジション)は落とす(GROUP BY 廃止でも維持)。"""
+    _seed_book(conn)
+    inst = _seed_instrument(conn, symbol="ZEROQTY.T")
+    _seed_bar(conn, inst, 1000, run_id=run_id)
+    _seed_position(conn, inst, "ben", 0, run_id=run_id)  # 消滅
+
+    positions, notes, exclusions = load_positions(conn, "DEMO_FUND", as_of=_AS_OF)
+    assert not any(p.instrument_id == inst for p in positions)
+    assert not any(f"instrument {inst}" in n for n in notes)
+    assert not any(e.instrument_id == inst for e in exclusions)


### PR DESCRIPTION
## 概要

A-12 監査 F-6(Issue #121)の是正。`load_positions` がポッド(fm)間をネットしてから時価評価するため、両建てがリスクエンジンに保有ゼロとして渡り (1) グロスレバ・資産クラスグロスの過小計上、(2) ネットゼロ銘柄の時価欠落の不検出、が起きていた。

実装指示書: `docs/tasks/T-021-risk-position-granularity.md`(本 PR に同梱)

## 変更(測度ごとに集計意味論を分離)

- `daily.load_positions`: 行=fm×instrument 単位で返す(GROUP BY 廃止)。時価欠落の Exclusion/notes は銘柄単位で重複排除
- `engine.RiskPosition`: `fm` フィールド追加(集計には不使用・由来開示用)
- `engine.guardrail_usage`: gross_leverage / single_asset_class_gross は行単位 Σ|value|(t014 設計判断3・ゲート G-4/G-8 と整合)、issuer_concentration は銘柄単位ネット後 abs(ゲートの abs(post_fund_qty) と同じ意味論)
- `engine.es95`: weights の符号付き加算は維持(同一銘柄の逆ポジション P&L は厳密に相殺)+ネット後ゼロ銘柄を weights から除外
- テスト 8 件追加(両建て・部分相殺・時価欠落 dedupe・行単位返却ほか)

## 検証

- tests/risk/ 130 pass、新規 8 件含む
- `test_engine_invariance.py` の snapshot は**不変**(両建てが無い入力では結果が変わらないことが期待値どおり)
- ruff 通過

## ガバナンス

リスクリミット=保護領域。独立役員審査 → #承認 通知 → みなし承認手続で統合する。

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)