### PR TITLE
T-023: 約定ベース売買代金の事後監視(F-12)+テスト異常系補強(F-14)

### DIFF
--- a/docs/reviews/t023-exec-turnover-review.md
+++ b/docs/reviews/t023-exec-turnover-review.md
@@ -1,0 +1,178 @@
+---
+review: t023-exec-turnover-monitor
+reviewed_sha: e27cf196c01907e41eeef2d29dabef6f743a529f
+reviewer: independent-officer
+review_date: 2026-08-04
+verdict: approve
+---
+
+# T-023 exec turnover monitor: 独立役員審査
+
+## 対象範囲
+- worktree: `/Users/mmiyazaki/Projects/sukifura/ryza/.claude/worktrees/agent-a71a6b09`
+- ブランチ: t023-exec-turnover-monitor
+- HEAD: e27cf196c01907e41eeef2d29dabef6f743a529f
+- 仕様書: `docs/tasks/T-023-f12-f14-exec-turnover-and-tests.md`
+
+## 骨子(各観点は下記に順次追記)
+1. 仕様との突合
+2. 検知条件の適用範囲(取りこぼし)
+3. 誤検出の分析
+4. 原子性と通知の整合
+5. 会計・記帳経路の不変原則
+6. G-7 本体の無変更確認
+7. F-14a/F-14b
+8. IPS ハードコード検査
+9. テスト実行
+10. 発見事項一覧・verdict
+
+## 1. 仕様との突合
+
+仕様書 T-023 §F-12 の実装要件を1件ずつ確認する。
+
+| 仕様要件 | 実装箇所 | 適合 |
+|---|---|---|
+| 検知ヘルパー `turnover_breach_after_execution(conn, execution_id)` を `src/ryza/gate/orders.py` に追加 | orders.py L547-624 | 適合 |
+| 入力は conn+execution_id | L547-552 のシグネチャ | 適合 |
+| 当該約定の JST 日付・book_id で約定ベースのみの当日累計を、before(除く)/after(含む) 双方で計算 | `_executed_turnover_before_and_after` L471-499(`FILTER (WHERE e.id <> %s)` で before、無条件 sum で after) | 適合 |
+| `_daily_turnover` の約定側クエリと同じ式 | 双方 `sum(abs(e.qty) * e.price)` + JOIN orders + `(executed_at AT TIME ZONE 'Asia/Tokyo')::date = trade_date`。**式は完全一致** | 適合 |
+| 上限 = `ips.hard_limits.daily_turnover_nav_max × NAV` | L610 `Decimal(str(ips.hard_limits.daily_turnover_nav_max)) * nav` | 適合。float→Decimal を str 経由で安全化 |
+| NAV はゲート判定時のスナップショット(`gate_log.state_ref`)から取る | `_nav_from_gate_log` L502-544(実行→注文→gate_log と辿り `state_ref->>'nav'` を Decimal 化) | 適合 |
+| dd_soft 半減は適用しない、docstring 根拠明記 | L515-516 に明記(半減=新規建て抑制の意味論、事後監視は暴走ガード本体 30%) | 適合 |
+| 返り値: 跨いだ場合のみ詳細、それ以外 None | L596-608(fail-closed)、L611-623(跨ぎ)、L624(それ以外 None) | 適合 |
+| **跨ぎ判定は `before ≤ limit < after`** | L611 `if before <= limit < after` | 適合 — 継続鳴動抑止 |
+| 同一トランザクション内で press outbox に urgent enqueue | runner.py L205-214 の `_execute_one` 内(呼び元 `run_pending` L260 が `with conn.transaction()` で囲む) | 適合 |
+| embed に before/after/上限/銘柄/注文 ID を含める | runner.py `_turnover_breach_embed` L50-99 に `before`, `after`, `limit_text`, `instrument_id`, `order_id`, `execution_id`(タイトル)を含む | 適合 |
+| G-7 本体は変更しない、docstring 1 行追記可 | compliance.py 差分は `_g7_turnover` docstring のみ(6 行追加、ロジック行 L505-518 は無変更) | 適合 |
+
+**仕様からの逸脱の妥当性評価**:
+
+- 「呼び出し箇所が runner.py」(仕様は demo.py と記載): 起草者の PR 本文で受容済み。実際には `execute.demo` は Broker 実装であり、`record_execution`/`apply_execution` を呼ぶのは runner.py の `_execute_one`(L175-185・L200)。仕様書の「デモ執行経路」を素直に読むと runner が正しい配線先(1 注文=1 トランザクション savepoint の唯一の呼び出し元)。**妥当**
+- 「NAV 出所を gate_log.state_ref」(仕様は order_ref とも読める記載): 仕様は「apply_execution が asset_class 抽出に使っているのと同じ経路」と指定しているが、apply_execution は `order_ref ->> 'asset_class'` を使う(L389-405)。実装は state_ref から NAV を取る。仕様書 L23 が「gate_log の order_ref JSON」と書きつつ「NAV はゲート判定時のスナップショット」と要求している点は、`_state_snapshot` が state_ref に NAV を保存する構造(orders.py L189-208)を前提にすれば、**state_ref が正しい格納先**。実装の判断は仕様の意図(判定時 NAV の再現性)に合致し、order_ref に NAV は元々書かれない(_proposal_snapshot は OrderProposal のフィールドのみ)。**妥当・むしろ実装のほうが正しい**
+
+## 2. 検知条件の適用範囲(取りこぼしの分析)
+
+**取りこぼし得るケースの列挙と評価**:
+
+- **book_id が異なる約定の混入**: 検知クエリは `WHERE o.book_id = %s`(L491)で book_id ごとに閉じる。当該約定の book_id を先に読み(L571-579)、その book_id 内でのみ集計。**取りこぼしなし**
+- **venue の扱い**: クエリは venue で絞らない。デモ経路と実行経路(将来)が同一 book_id なら同じ枠として合算される。**妥当**(G-7 の枠は book 単位で1つ)
+- **JST 日付境界**: `(e.executed_at AT TIME ZONE 'Asia/Tokyo')::date` で切る。`_daily_turnover` と同じ規約。UTC のみで見ると跨る対でも JST で正しく分離される。test_trade_date_scoped_by_jst で回帰固定。**妥当**
+- **gate_log を持たない注文経路**: スキーマ上不可能(orders.gate_log_id NOT NULL、migrations/0014 L66)。`gate_and_record` 以外に orders を作る API は無い(A-3 突合の対象)。**構造的に発生しない**
+- **エッジトリガの取りこぼし境界**: `before ≤ limit < after`
+  - `before == limit` かつ `after > limit`: 発火する(≤ を含むため)。**妥当**
+  - `before < limit` かつ `after == limit`: **発火しない**(限界内ちょうどは超過ではない)。**妥当**
+  - `before == limit` かつ `after == limit`: 数値上あり得ないケース(qty>0/price≥0 で after ≥ before + 0)。**問題なし**
+  - **重要な観察**: 最初の跨ぎ後、超過状態が持続する日中に **NAV が下方修正**されて limit が下がり(ただし本実装では NAV は判定時固定なので該当しない)、その後の約定で新たに before/after が同じ状態のまま鳴らない設計。判定 NAV が約定ごとに違えば同一日でも limit が変わり得るが、本実装は約定に紐づく gate_log の判定時 NAV を使うため、**時系列で異なる注文の判定 NAV が混在**する。同一日内で NAV が動くケース(場中の再評価)では、最初の跨ぎ検知に使う NAV は当該約定の gate_log の NAV(最新版)である一方、before の累計は過去約定の実約定価格。**limit と累計の基準が不一致**。ただし仕様の意図は「その約定の判定時に使った NAV で見て、その約定が枠を破ったか」であり、当該約定の判定 NAV は当該約定の gate_log から取るのが自然。**設計妥当だが微妙な意味論なので docstring への追記が望ましい**(発見: 軽微)
+- **同時・並行実行時の累計の読み方**: `_execute_one` は `run_pending` から `with conn.transaction()` で囲まれた 1 注文 1 savepoint 内で呼ばれる。`record_execution` は `SELECT ... FOR UPDATE` で order 行を掴んでから executions を INSERT する(L335)ため、同一 order への並行 fill は直列化される。異なる order の並行 fill は?
+  - 検知クエリは `AGG WHERE book_id AND date` で走る。トランザクション分離レベルが READ COMMITTED(psycopg 既定)なら、別トランザクションが未コミットの executions は見えない。実際には savepoint 内 UPDATE 済みなので self では見える。**別注文の並行執行**: `_execute_one` は各注文で `with conn.transaction()` を張り直すので同一 connection 上は逐次。**別 connection**(将来の並列 worker)からの並行は本 PR の想定外(gate_and_record は advisory lock で直列化するが、runner 側にはロックが無い)。実装のカレント配線では順次実行なので**妥当**、将来並列化する場合の課題として認識しておく(発見: 中)
+- **`_daily_turnover` の約定側との突合**: `_daily_turnover` の pending 側(orders passed/submitted)は本実装の検知には入らない(仕様通り「約定ベースのみ」)。事後監視は約定成立が前提なので **妥当**
+- **fee の扱い**: `_daily_turnover` の約定側もフィーを合算しない(`abs(qty) * price` のみ)。本実装も同一式なので突合齟齬なし。**妥当**
+
+**結論**: 取りこぼしは実装配線内では発見されず、仕様意図通り。将来の並列 worker 導入時は runner 側の advisory lock か SERIALIZABLE 分離が必要になる旨を認識しておくべき(現行は既知の制約下で妥当)。
+
+## 3. 誤検出の分析
+
+- **枠内約定・複数注文の順次執行**: test_within_limit_returns_none / test_edge_trigger_fires_once_on_crossing の前半で回帰固定
+- **既に超過中の追加約定**: エッジトリガで抑止(test_no_alarm_while_already_over_limit)
+- **前日約定は当日累計に入らない**: test_trade_date_scoped_by_jst
+- **`_execute_one` の再試行経路**: 失敗すると savepoint で巻き戻る → executions 行も outbox 行も残らない。次回 `run_pending` で同じ passed 注文が再処理され、成功時のみ enqueue される。**二重通知は発生しない**
+- **fail-closed が正常系で誤発火**: `_nav_from_gate_log` が None を返すのは gate_log 欠落・state_ref NULL・nav キー欠落・非正 NAV のみ。正常な `gate_and_record` 経路では `_state_snapshot` が nav を str で必ず入れる(L189-190、nav=None 時は "None" を回避すべく `_s()` を通すが、`state.nav is None` のケースだと文字列 "None" が入るリスク)。
+  - **要確認**: `_state_snapshot._s(None)` は None を返す。dict 上は `"nav": None`。`_nav_from_gate_log` は `nav_raw is None` を検知して fail-closed の理由を返す(L536-537)。ゲート判定時に nav=None のケース(fail-closed で block)では state_ref にも None が入るが、そもそも block なら executions は生成されないので、この経路には到達しない。**設計整合済み**
+
+## 4. 原子性と通知の整合
+
+- `run_pending` L260 が `with conn.transaction()` を張り、`_execute_one` 内の record_execution / post_fill / advance_order_status / turnover_breach 検知 / enqueue が同一 savepoint 内で実行される。仕訳失敗や advance_order_status 失敗で例外が発生すると savepoint 全体が巻き戻り、outbox 行も消える。**通知だけ残る経路は無い**
+- 逆に「約定は残ったが通知だけ失われる」経路: 
+  - 検知ヘルパが例外を投げる → 例外は `_execute_one` 内で catch されない → run_pending L265 の except で拾い、savepoint 全体巻き戻し。約定も outbox も両方消える(次回再試行)。**通知だけ失う経路は無い**
+  - enqueue が例外 → 同上で巻き戻し
+- **配送側の冪等**: outbox は sent_at IS NULL で条件付き mark(既存)。跨ぎ通知が二重送信になる経路も無し
+
+**唯一の懸念**: 巻き戻し後の再試行で、前回の約定が保存されていないため次回は「新規約定」として扱われ、正しく通知される。実装配線は健全。
+
+## 5. 会計・記帳経路の不変原則
+
+- **trading.executions への記帳**: runner.py `_execute_one` は `record_execution` 経由(L175)。本 PR の変更行に直接 INSERT は無い(git grep 済み)
+- **ledger への記帳**: `posting.post_fill` 経由(runner.py L186)。本 PR の変更行に直接 INSERT/UPDATE は無い
+- **テストコードの直接 INSERT**: test_turnover_breach.py `_insert_execution`(L64-85)が `trading.executions` に直接 INSERT する。理由は同ファイル冒頭 docstring(L1-12)で明示: 「`record_execution` は累積約定 ≤ 注文数量 制約を持つため、NAV×30% を跨ぐ大きな累計を単一注文で作れない」「検知ヘルパは executions の合算式のみを見るので直接 INSERT でも意味論は同一」。docstring の理由付けは**妥当**
+- **テストの分離**: gate/conftest.py の `conn` フィクスチャ(L38-46)が rollback で隔離。共有 DB に書き残さない。**妥当**
+- **test_fail_closed_when_gate_log_state_ref_lacks_nav の DISABLE TRIGGER**: 追記オンリー制約を一時的に外して state_ref を書き換えるが、DDL はトランザクション内で巻き戻る(rollback される)。**テスト専用の破壊がリポジトリに漏れない**
+
+## 6. G-7 本体の無変更確認
+
+git diff で機械的に確認済み: `src/ryza/gate/compliance.py` の変更は `_g7_turnover` の docstring 追加 6 行のみ(L498 の関数シグネチャ以降のロジック行に変更なし)。**適合**
+
+## 7. F-14a/F-14b
+
+**F-14a**(tests/risk/test_daily.py の 3 テスト追加):
+
+1. `test_f14a_future_entry_date_goes_to_pending`: 最終スナップより未来の entry_date が points に混入せず pending_flows に出ることを固定。points の `net_flow` を before(投入前)と直接比較しており、二重計上・黙消の両方を塞ぐ。**適合**
+2. `test_f14a_entry_before_series_start_attaches_to_first_point`: 系列開始より過去の entry_date は先頭点に寄る(実測経路の固定)。past_amount と `points[0].net_flow` の増分を assert し、pending が空であることも同時検証。**適合(仕様通り「実測結果を期待値として固定」)**
+3. `test_f14a_sum_preservation_across_anomalies`: 過去・当日・未来の 3 種フローを投入し、`points + pending` の増分総和 == 投入総和を検証。**適合**
+
+**F-14b**(tests/gate/test_lock.py + pyproject.toml):
+
+- ファイル冒頭 docstring に分離の理由を追加(commit する理由・trading_state singleton の干渉・原状復帰の仕組み)。**仕様1適合**
+- `pytestmark = pytest.mark.commits_shared_state` をファイル全体に付与。**仕様2適合**
+- pyproject.toml `[tool.pytest.ini_options]` の `markers` に `commits_shared_state` を登録。名前・説明が spec 通り。**整合**
+- `committed_prereqs` フィクスチャ docstring に「commit を伴う理由・干渉し得る対象・原状復帰の仕組み」を追記。既存の try/finally は変更なし(既に finally 済み)。**仕様3適合**
+
+## 8. IPS 値のハードコード検査
+
+grep 結果:
+
+- `src/ryza/gate/orders.py`: `30%` は L516 の docstring のみ(半減不適用の説明文)
+- `src/ryza/execution/runner.py`: マッチなし
+- `tests/gate/test_turnover_breach.py`: L10 docstring と L91 コメントの `30%` のみ
+
+判定処理(`limit = Decimal(str(ips.hard_limits.daily_turnover_nav_max)) * nav`)と embed 表示(`float(breach.limit / breach.nav):.0%`)はいずれも IPS 値と NAV から動的算出。**IPS 変更時に表示・判定が乖離するリスクはない**。**適合(受け入れ基準クリア)**
+
+## 9. テスト実行結果
+
+```
+tests/gate/test_turnover_breach.py 5 passed
+tests/gate/test_lock.py           1 passed
+tests/risk/test_daily.py -k f14a  3 passed
+ruff check src/ryza/gate/ src/ryza/execution/ tests/gate/  All checks passed!
+```
+
+追加のエッジトリガ紙上検証(before ≤ limit < after)を実施:
+
+| before | limit | after | 期待 | 実測 |
+|---|---|---|---|---|
+| 100 | 100 | 101 | 発火 | True |
+| 99 | 100 | 100 | 非発火 | False |
+| 99 | 100 | 101 | 発火 | True |
+| 101 | 100 | 102 | 非発火(超過継続) | False |
+| 0 | 100 | 100 | 非発火(等しいは超過ではない) | False |
+
+すべて意味論通り。「跨ぎ=超過に転じた瞬間」の定義に整合。
+
+## 10. 発見事項一覧 と verdict
+
+### 発見事項
+
+| 重要度 | 分類 | 内容 |
+|---|---|---|
+| 軽微 | 意味論の明示 | 同一 book 同一 JST 日の異なる注文が異なる NAV スナップショット(場中の再評価)を持つ場合、「当該約定の gate_log の NAV × 30%」を limit とする一方 before は過去約定(別 NAV で判定された)を含む。現行 NAV スナップショットは 1 日固定運用なので実害はないが、日中 NAV 更新が導入された際の意味論が曖昧。docstring での「limit は本約定判定時の NAV、before/after は当日累計」の意味の明示があると将来の保守で助かる。**現行運用では問題なし** |
+| 中 | 将来の並列化 | `_execute_one` は同一 connection 内では逐次だが、複数 connection からの並列 `run_pending` に対する直列化は現状無い(`gate_and_record` は advisory lock を張るが runner は張らない)。並列 worker 導入時は runner 側にも book_id ロックを入れる必要がある。**T-023 のスコープ外**(実装当時の設計で妥当) |
+
+### 肯定的確認(問題を探して見つからなかった点)
+
+- **仕様の 11 項目すべて実装済み**(§1 の突合表): 検知ヘルパーの入出力/エッジトリガ/NAV 出所/dd_soft 不適用+docstring 根拠/同一トランザクション内 enqueue/embed の必須フィールド/G-7 本体無変更、いずれも仕様に厳密に一致
+- **原子性の壁**: `_execute_one` は savepoint 内で 記帳→検知→enqueue を実行し、通知だけ残る/通知だけ失う経路は存在しない
+- **fail-closed 経路**: NAV 判定不能を黙殺せず TurnoverBreach を返し、embed で「判定不能」を表示(数値偽装なし)。実運用では到達し得ないが、A-3 検知経路との整合性として妥当
+- **記帳経路の不変原則**: executions は record_execution 経由のみ、ledger は post_fill 経由のみ、本 PR で直接 INSERT/UPDATE の混入なし。テストの直接 INSERT は理由付き docstring 付きで rollback 隔離
+- **G-7 本体無変更**: git diff で機械的に確認、docstring 6 行追加のみ
+- **IPS ハードコードなし**: 判定・embed ともに `ips.hard_limits.daily_turnover_nav_max × NAV` から動的算出
+- **エッジトリガの意味論**: 5 通りの境界パターンすべて仕様の意図に整合
+- **F-14a**: 3 テストが「未来 → pending」「過去 → 先頭点」「総和保存」を独立に固定、実測固定は仕様の指定通り
+- **F-14b**: マーカー登録・pytestmark 付与・docstring 追記が仕様の 3 項目に対応
+- **ruff クリーン**、対象テスト全通過(6/6 + F-14a 3/3)
+
+### verdict
+
+**approve**
+
+根拠: T-023 仕様書の全要件を実装しており、逸脱項(呼び出し配線 runner.py・NAV 出所 state_ref)は仕様の意図に照らして**むしろ実装のほうが正確**(demo.py は Broker 実装であり `record_execution` を呼ばない、_state_snapshot に NAV が格納される構造から state_ref が正しい格納先)。原子性・fail-closed・エッジトリガ・G-7 本体無変更・IPS ハードコードなしの受け入れ基準はすべて満たし、テストは対象範囲で全通過・ruff クリーン。発見事項は「軽微」1 件(将来保守向け docstring 追記の助言)と「中」1 件(スコープ外の将来並列化課題)のみで、いずれも **request_changes のブロッキング要因ではない**。
+
+

--- a/docs/tasks/T-023-f12-f14-exec-turnover-and-tests.md
+++ b/docs/tasks/T-023-f12-f14-exec-turnover-and-tests.md
@@ -1,0 +1,52 @@
+# T-023: 約定ベース売買代金の事後監視(F-12)+リスク/ゲートのテスト異常系補強(F-14) — Issue #124
+
+- 起草: 2026-08-04 設計リード / 前提: F-6(PR #133)統合済み main に対して作業
+- 前提知識: CLAUDE.md、docs/reviews/a12/00-adjudication.md §3(pass2-3 / pass5-2 / pass5-4)、src/ryza/gate/{compliance,orders}.py、src/ryza/execution/demo.py、src/ryza/risk/{daily,navflow}.py、tests/gate/test_lock.py
+- **保護領域**(コンプラゲート・リスクリミット周辺)。統合は設計リードが独立役員審査+みなし承認手続で行う
+- 本仕様書自体を実装ブランチの最初のコミットとして `docs/tasks/T-023-f12-f14-exec-turnover-and-tests.md` に含めること
+
+## F-12: G-7 の TOCTOU(注文時価格と約定価格の乖離)
+
+### 問題(pass2-3)
+
+G-7(compliance.py `_g7_turnover` L497-518)は「当日累計+本注文 ≤ NAV×30%」を**注文時価格**(limit_price / ref_price)で評価する。成行のスリッページで約定額面が膨らむと、ゲート通過時点では枠内でも**約定後には枠超過**が起こり得る。累計側(`orders._daily_turnover` L133-162)は約定を実約定価格で数えるため**次の注文からは自動的に閉まる**が、超過が起きたこと自体は誰も検知・通知しない。
+
+### 是正方針(設計リード裁定)
+
+**事後遮断はしない(できない — 既に約定済み)。約定ベースの累計が上限を跨いだ瞬間を決定論的に検知し、`#運営` へ urgent 通知する**。以後の注文は現行 G-7 が自動的に塞ぐので、応答は検知・通知で足りる。LLM は関与しない。
+
+### 実装
+
+1. **検知ヘルパー** `src/ryza/gate/orders.py` に追加(名称例 `turnover_breach_after_execution`):
+   - 入力: conn、execution_id(適用済みの約定)
+   - 当該約定の JST 日付・book_id で**約定ベースのみ**の当日累計(`trading.executions` を実約定価格で合算 — `_daily_turnover` の約定側クエリと同じ式)を、**当該約定を含む額(after)と除いた額(before)**の両方で計算する
+   - 上限 = `ips.hard_limits.daily_turnover_nav_max × NAV`。**NAV は当該注文のゲート判定時のスナップショット**(`compliance.gate_log` の order_ref JSON — apply_execution L389-405 が asset_class 抽出に使っているのと同じ経路)から取る。理由: ゲートが適用した上限と同一基準で跨ぎを判定でき、再読み込みによる非決定性(日中の NAV 変動)を持ち込まない。dd_soft の半減は適用しない(半減は「新規建て注文の抑制」の意味論であり、事後監視は暴走ガード本体の 30% に対して行う — 判断根拠として docstring に明記)
+   - 返り値: 跨いだ場合のみ詳細(book_id・日付・before/after・上限・execution_id)、それ以外 None。**跨ぎ判定は `before ≤ limit < after`** — 超過状態が続く限り毎約定で鳴らさない(通知が毎回赤だと意味を失う — navflow.urgent_pending L257 と同じ設計判断)
+2. **呼び出し**: デモ執行経路(src/ryza/execution/demo.py が record_execution/apply_execution を呼ぶ箇所)で、適用成功後に検知ヘルパーを呼び、跨ぎがあれば **同一トランザクション内で** press outbox に urgent で enqueue(risk/daily.py L456 の `enqueue(conn, channel_ops, embed, run.run_id, urgent=True)` の流儀)。embed 本文には before/after/上限/銘柄/注文 ID を含める
+3. ゲート側(G-7 本体)は**変更しない**。注文時価格ベースの事前評価は「近似としては正しく、事後監視とセットで完結する」— この構図を `_g7_turnover` の docstring に1行追記してよい(ロジック変更は不可)
+
+## F-14a: load_nav_series の異常タイムスタンプテスト(pass5-2)
+
+`src/ryza/risk/daily.py` L106-123 `load_nav_series` / `src/ryza/risk/navflow.py` の既存挙動(未来仕訳は pending_flows へ・黙って落とさない)を**リグレッション固定**する DB テストを tests/risk/ に追加:
+
+1. **測定日(最終スナップ)より未来の entry_date を持つ外部フロー仕訳** → points に混入せず `pending_flows` に出る
+2. **系列開始(最初の snap_date)より過去の entry_date を持つ仕訳** → 現行挙動を実測し、その挙動を期待値として固定(「最初のスナップに BOP 帰属」なら、そう。実測結果が「黙って消える」だった場合は**テストを書かず設計リードに差し戻す** — 是正が別途要るため)
+3. どちらも合計フロー額が保存されること(points+pending の総和が投入額と一致)
+
+## F-14b: tests/gate/test_lock.py の分離の明示(pass5-4)
+
+`committed_prereqs`(L26-60)は autocommit 接続で `ops.trading_state` / `risk.limits_state` を commit する(advisory lock の複数接続検証に必要)。並行実行での干渉リスクを**明示**する:
+
+1. フィクスチャ docstring に「commit を伴う理由・干渉し得る対象(trading_state は singleton)・原状復帰の仕組み」を明記
+2. pytest マーカー(例 `@pytest.mark.commits_shared_state`)を pyproject.toml の markers に登録してファイル全体に付与 — 将来 xdist 等を導入するときに直列化対象を機械的に選別できるようにする(現状の実行構成は変更しない)
+3. 後片付け(L47-60)の原状復帰がテスト失敗時にも走ることを確認(finally 済みならそのまま)
+
+## テスト(tests/gate/ ほか)
+
+- F-12: 跨ぎ検知の単体+DB テスト — (a) before ≤ limit < after で通知1件、(b) 既に超過中の追加約定では鳴らない、(c) 枠内なら None、(d) gate_log スナップショットから NAV を取れないケース(異常)は**fail-closed で urgent**(検知不能を黙殺しない — 理由コード付き)
+- F-14a: 上記 1〜3
+- 既存スイート全通過(特に tests/gate/ の G-7 既存テストが無変更で通ること)
+
+## 受け入れ基準
+
+全テスト+ruff 通過 / G-7 本体のロジック無変更 / 通知は跨ぎの1回のみ(エッジトリガ)/ LLM 非関与 / ips.yaml 値のハードコードなし / コミットは日本語+`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`、push しない(統合は設計リードが行う)。DB テストは `RYZA_DATABASE_URL=postgresql://ryza:ryza@localhost:15432/ryza`、worktree では `PYTHONPATH=$PWD/src` 必須

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,10 @@ select = ["E", "F", "I", "W", "UP", "B"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v"
+# 明示的なマーカー登録(未登録マーカーは pytest が PytestUnknownMarkWarning を出す)。
+# F-14b(Issue #124 pass5-4): commit を伴うテストを機械的に選別・直列化するための
+# マーカー。現状の実行構成は変更しないが、将来 xdist 等で並列化する際に
+# ``-m "not commits_shared_state"`` で分離できるようにする。
+markers = [
+    "commits_shared_state: テスト DB に対して commit を伴い共有状態(ops.trading_state 等)を変更するテスト。原状復帰は finally で行うが、並行実行では他テストと干渉し得るため直列化対象として明示する(F-14b / Issue #124)",
+]

--- a/src/ryza/execution/runner.py
+++ b/src/ryza/execution/runner.py
@@ -59,7 +59,11 @@ def _turnover_breach_embed(breach: TurnoverBreach) -> dict[str, Any]:
         )
         title = f"⚠ G-7 事後監視: NAV 判定不能({breach.book_id} {breach.trade_date})"
     else:
-        limit_text = f"¥{breach.limit:,.0f}(NAV ¥{breach.nav:,.0f} × 30%)"
+        # 比率は limit/nav から動的に出す(IPS 値のハードコード禁止 — 設定変更時に表示が嘘になる)。
+        limit_text = (
+            f"¥{breach.limit:,.0f}(NAV ¥{breach.nav:,.0f}"
+            f" × {float(breach.limit / breach.nav):.0%})"
+        )
         title = (
             f"⚠ G-7 上限跨ぎ検知({breach.book_id} {breach.trade_date}"
             f" — 約定 {breach.execution_id})"

--- a/src/ryza/execution/runner.py
+++ b/src/ryza/execution/runner.py
@@ -30,14 +30,69 @@ from zoneinfo import ZoneInfo
 
 import psycopg
 
+from ryza.bot import COLOR_FLASH, DISCLAIMER
+from ryza.bot.outbox import enqueue
 from ryza.execution.broker import EXPIRED, FILLED, REJECTED, Broker, BrokerOrder, BrokerResult
-from ryza.gate.orders import advance_order_status, record_execution
+from ryza.gate.orders import (
+    TurnoverBreach,
+    advance_order_status,
+    record_execution,
+    turnover_breach_after_execution,
+)
 from ryza.ledger import posting
 
 _JST = ZoneInfo("Asia/Tokyo")
 
 # ledger(post_fill)が記帳できる side。short/cover は会計未対応のため執行しない。
 _LEDGER_SIDES = frozenset({"buy", "sell"})
+
+
+def _turnover_breach_embed(breach: TurnoverBreach) -> dict[str, Any]:
+    """G-7 上限跨ぎ(F-12)通知の embed。#運営 へ urgent で1通。
+
+    NAV が取れなかった fail-closed 経路は理由を明示し、上限は「判定不能」と書く
+    (数値を偽装しない — 監査再現性)。
+    """
+    if breach.nav is None:
+        limit_text = (
+            f"判定不能({breach.nav_missing_reason or 'gate_log から NAV を取得できない'})"
+        )
+        title = f"⚠ G-7 事後監視: NAV 判定不能({breach.book_id} {breach.trade_date})"
+    else:
+        limit_text = f"¥{breach.limit:,.0f}(NAV ¥{breach.nav:,.0f} × 30%)"
+        title = (
+            f"⚠ G-7 上限跨ぎ検知({breach.book_id} {breach.trade_date}"
+            f" — 約定 {breach.execution_id})"
+        )
+    fields: list[dict[str, Any]] = [
+        {
+            "name": "約定ベース当日累計",
+            "value": (
+                f"before ¥{breach.before:,.0f} → after ¥{breach.after:,.0f}"
+                f"(注文 {breach.order_id} / instrument {breach.instrument_id})"
+            ),
+            "inline": False,
+        },
+        {"name": "上限", "value": limit_text, "inline": False},
+    ]
+    if breach.nav_source_gate_log_id is not None:
+        fields.append(
+            {
+                "name": "NAV 出所",
+                "value": f"compliance.gate_log #{breach.nav_source_gate_log_id}",
+                "inline": True,
+            }
+        )
+    return {
+        "title": title,
+        "description": (
+            "約定ベースの当日売買代金が G-7 上限を跨いだ(F-12 事後監視)。"
+            "以後の注文は現行 G-7 が塞ぐため事後遮断は行わない。"
+        ),
+        "color": COLOR_FLASH,
+        "fields": fields,
+        "footer": {"text": DISCLAIMER},
+    }
 
 
 def _passed_orders(conn: psycopg.Connection, book_id: str) -> list[dict[str, Any]]:
@@ -139,7 +194,21 @@ def _execute_one(
             posted_by="execution.runner",
         )
         advance_order_status(conn, order_id, "filled")
-        return {
+        # F-12: 約定ベース累計が G-7 上限を跨いだ瞬間を検知し、urgent 通知する。
+        # 事後遮断はしない(既に約定済み)— 以後の注文は現行 G-7 が自動的に塞ぐ。
+        # 同一トランザクション内で enqueue することで、約定の巻き戻し(トランザクション
+        # 失敗)と通知の存在を一致させる(通知だけ残ることを防ぐ)。
+        breach = turnover_breach_after_execution(conn, execution_id)
+        breach_notified: int | None = None
+        if breach is not None:
+            breach_notified = enqueue(
+                conn,
+                "ops",
+                _turnover_breach_embed(breach),
+                run_id,
+                urgent=True,
+            )
+        outcome: dict[str, Any] = {
             "order_id": order_id,
             "status": "filled",
             "execution_id": execution_id,
@@ -148,6 +217,9 @@ def _execute_one(
             "price": str(result.price),
             "fee": str(fee),
         }
+        if breach_notified is not None:
+            outcome["turnover_breach_outbox_id"] = breach_notified
+        return outcome
 
     if result.status == REJECTED:
         advance_order_status(conn, order_id, "rejected")

--- a/src/ryza/gate/compliance.py
+++ b/src/ryza/gate/compliance.py
@@ -498,6 +498,12 @@ def _g7_turnover(ctx: _Ctx) -> list[Reason]:
     """G-7 売買代金: 当日累計+本注文 ≤ NAV の 30%(IPS §3.2 暴走ガード)。
 
     dd_soft(DD 15% ソフトリミット)中の新規建ては枠を半減して評価する(G-10 の解釈)。
+
+    事前評価は**注文時価格**(limit_price/ref_price)で行う近似であり、成行のスリッページ
+    で約定額面が事後に上限を跨ぐ TOCTOU がありうる(F-12)。事後の遮断はできない
+    (既に約定済み)ため、跨ぎ検知は ``gate.orders.turnover_breach_after_execution``
+    が約定ベースの累計で行い、跨いだ瞬間だけ ``#運営`` へ urgent 通知する。以後の
+    注文はここ(現行 G-7)が自動的に塞ぐ。
     """
     assert ctx.state.nav is not None and ctx.state.daily_turnover is not None
     limit = _dec(ctx.ips.hard_limits.daily_turnover_nav_max) * ctx.state.nav

--- a/src/ryza/gate/orders.py
+++ b/src/ryza/gate/orders.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
@@ -444,10 +444,192 @@ def apply_execution(conn: psycopg.Connection, execution_id: int, *, run_id: int)
     return True
 
 
+# ── F-12: 約定ベース売買代金の跨ぎ検知(事後監視)─────────────────────────────
+@dataclass(frozen=True)
+class TurnoverBreach:
+    """G-7 上限を約定ベースの累計が跨いだ瞬間の詳細(通知本体で使う)。
+
+    ``before ≤ limit < after`` の**エッジトリガ**でのみ生成する — 超過状態が続く限り
+    毎約定で鳴らすと通知の意味が失われる(``navflow.urgent_pending`` と同じ設計判断)。
+    ``nav_source`` は上限計算に使った NAV の出所(``gate_log_id`` の state_ref スナップ
+    ショット)。事後監査で「どの NAV で上限を出したか」を再現できるようにする。
+    """
+
+    book_id: str
+    trade_date: date
+    execution_id: int
+    order_id: int
+    instrument_id: int
+    before: Decimal  # 当該約定を除いた約定ベース当日累計
+    after: Decimal  # 当該約定を含めた同累計
+    limit: Decimal  # daily_turnover_nav_max × NAV
+    nav: Decimal | None  # 上限計算に使った NAV(取れなければ None → fail-closed)
+    nav_source_gate_log_id: int | None
+    nav_missing_reason: str | None = None  # fail-closed 経路の理由
+
+
+def _executed_turnover_before_and_after(
+    conn: psycopg.Connection,
+    book_id: str,
+    trade_date: date,
+    execution_id: int,
+) -> tuple[Decimal, Decimal] | None:
+    """当日(JST)の約定ベース累計を **execution_id を含まない/含む**で返す。
+
+    ``_daily_turnover`` の約定側クエリと同じ式(Σ|qty|×price)。当該約定が対象日に
+    無ければ None(呼び出し側の前提違反)。
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COALESCE(sum(abs(e.qty) * e.price) FILTER (WHERE e.id <> %s), 0) AS before_amt,
+                COALESCE(sum(abs(e.qty) * e.price), 0) AS after_amt,
+                bool_or(e.id = %s) AS has_target
+            FROM trading.executions e
+            JOIN trading.orders o ON o.id = e.order_id
+            WHERE o.book_id = %s
+              AND (e.executed_at AT TIME ZONE 'Asia/Tokyo')::date = %s
+            """,
+            (execution_id, execution_id, book_id, trade_date),
+        )
+        row = cur.fetchone()
+    if row is None or not row[2]:
+        return None
+    return Decimal(row[0]), Decimal(row[1])
+
+
+def _nav_from_gate_log(
+    conn: psycopg.Connection, execution_id: int
+) -> tuple[Decimal | None, int | None, str | None]:
+    """当該約定に紐づくゲート判定スナップショット(``compliance.gate_log.state_ref``)
+    から NAV を取り出す。取れない場合は理由付きで None を返す(fail-closed)。
+
+    設計判断: NAV は**ゲート判定時に固定した値**を使う(``_state_snapshot`` が
+    ``state_ref.nav`` に文字列で保存している)。判定時の値を再利用することで:
+
+    - ゲートが適用した上限と同一基準で「跨ぎ」を判定できる(発注時の枠と事後累計の
+      比較が同じ NAV で行える)
+    - 判定時と事後監視時の間の NAV 変動(日中の再評価等)による非決定性を持ち込まない
+
+    dd_soft の枠半減は適用しない — 半減は「新規建て注文の抑制」の意味論であり、
+    事後監視は暴走ガード本体の 30%(``daily_turnover_nav_max``)に対して行う。
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT g.id, g.state_ref
+            FROM trading.executions e
+            JOIN trading.orders o ON o.id = e.order_id
+            JOIN compliance.gate_log g ON g.id = o.gate_log_id
+            WHERE e.id = %s
+            """,
+            (execution_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None, None, "gate_log が紐づかない(執行手順違反 — A-3 の検知対象)"
+    gate_log_id, state_ref = row
+    if state_ref is None:
+        return None, gate_log_id, "gate_log.state_ref が NULL"
+    nav_raw = state_ref.get("nav") if isinstance(state_ref, dict) else None
+    if nav_raw is None:
+        return None, gate_log_id, "gate_log.state_ref に nav が無い"
+    try:
+        nav = Decimal(str(nav_raw))
+    except Exception as exc:  # noqa: BLE001 - 数値化できない値も fail-closed
+        return None, gate_log_id, f"nav を Decimal 化できない: {nav_raw!r}({exc})"
+    if nav <= 0:
+        return None, gate_log_id, f"nav が非正: {nav}"
+    return nav, gate_log_id, None
+
+
+def turnover_breach_after_execution(
+    conn: psycopg.Connection,
+    execution_id: int,
+    *,
+    ips: IPSConfig | None = None,
+) -> TurnoverBreach | None:
+    """約定適用後の G-7 上限跨ぎを検知する(F-12 事後監視)。
+
+    - 当該約定の JST 日付・book_id で **約定ベースのみ** の当日累計を計算し、
+      本約定を **含む額(after)と除いた額(before)** を求める
+    - 上限は ``ips.hard_limits.daily_turnover_nav_max × NAV``。NAV は当該注文のゲート
+      判定スナップショット(``compliance.gate_log.state_ref``)から取る
+    - 跨ぎ判定は ``before ≤ limit < after`` の**エッジトリガ**。既に超過中の追加約定
+      では鳴らさない
+    - NAV スナップショットが取れない異常系は **fail-closed** — after が有限値なら
+      「跨いだ」扱いで返し、呼び出し側で urgent 通知する(検知不能を黙殺しない)
+
+    返り値は ``TurnoverBreach``(跨ぎ or fail-closed)、それ以外は ``None``。ips は
+    未指定なら発効値をロードする。
+    """
+    if ips is None:
+        ips, _ = load_and_validate()
+    # 執行と book/trade_date/instrument/order を1回で読む(SELECT を減らす)。
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT o.book_id, o.id, o.instrument_id,
+                   (e.executed_at AT TIME ZONE 'Asia/Tokyo')::date
+            FROM trading.executions e
+            JOIN trading.orders o ON o.id = e.order_id
+            WHERE e.id = %s
+            """,
+            (execution_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"約定 {execution_id} が存在しない")
+    book_id, order_id, instrument_id, trade_date = row
+    before_after = _executed_turnover_before_and_after(
+        conn, book_id, trade_date, execution_id
+    )
+    if before_after is None:
+        # 対象日に当該約定が見つからない(理論上は上の SELECT と齟齬)。
+        return None
+    before, after = before_after
+    nav, gate_log_id, nav_reason = _nav_from_gate_log(conn, execution_id)
+    if nav is None:
+        # NAV が取れなければ判定不能 → fail-closed で urgent 側に倒す(A-3 と同じ姿勢)。
+        # after が有限値であればイベントとして上げる(呼び出し側は urgent 通知)。
+        return TurnoverBreach(
+            book_id=book_id,
+            trade_date=trade_date,
+            execution_id=execution_id,
+            order_id=order_id,
+            instrument_id=instrument_id,
+            before=before,
+            after=after,
+            limit=Decimal(0),
+            nav=None,
+            nav_source_gate_log_id=gate_log_id,
+            nav_missing_reason=nav_reason,
+        )
+    # 上限は IPS の hard_limits(発効値)。float → Decimal は str 経由で二進誤差を避ける。
+    limit = Decimal(str(ips.hard_limits.daily_turnover_nav_max)) * nav
+    if before <= limit < after:  # エッジトリガ
+        return TurnoverBreach(
+            book_id=book_id,
+            trade_date=trade_date,
+            execution_id=execution_id,
+            order_id=order_id,
+            instrument_id=instrument_id,
+            before=before,
+            after=after,
+            limit=limit,
+            nav=nav,
+            nav_source_gate_log_id=gate_log_id,
+        )
+    return None
+
+
 __all__ = [
     "OrderStatusError",
+    "TurnoverBreach",
     "advance_order_status",
     "apply_execution",
     "gate_and_record",
     "record_execution",
+    "turnover_breach_after_execution",
 ]

--- a/tests/gate/test_lock.py
+++ b/tests/gate/test_lock.py
@@ -4,6 +4,15 @@
 advisory lock で封鎖していることを確認する。前提行(trading_state・limits_state)は
 両接続から見える必要があるため一時的に commit し、teardown で原状復帰する
 (test_store.py の autouse フィクスチャとは独立の接続を使うため専用ファイルに置く)。
+
+**分離の明示**(F-14b / Issue #124 pass5-4)。このファイルのテストは他の DB テストと
+異なり、``committed_prereqs`` が **autocommit 接続で commit する**(advisory lock を
+複数接続で検証するには両接続から前提行が見える必要があるため)。他テストは通常
+「1 テスト = 1 トランザクション + 最後に rollback」で隔離するが、本ファイルは
+その原則を意図的に外している(原状復帰は finally で行う)。並行実行(pytest-xdist
+等)を導入する場合、このファイルは ``commits_shared_state`` マーカーで直列化対象と
+して選別できるようにしてある(pyproject.toml `markers`)。現状の実行構成は
+逐次実行のため変更不要だが、干渉リスクの存在をコード上に固定しておく。
 """
 
 from __future__ import annotations
@@ -19,13 +28,40 @@ from ryza.ledger import create_run
 
 from .conftest import jp_stock_proposal
 
+# ファイル全体を ``commits_shared_state`` として印字。将来 xdist 等を入れるときに
+# ``-m "not commits_shared_state"`` で並列テストから外し、単独ワーカーで直列に流せる。
+pytestmark = pytest.mark.commits_shared_state
+
 _NAV = Decimal(10_000_000)
 _CASH = Decimal(5_000_000)
 
 
 @pytest.fixture
 def committed_prereqs(migrated_db):
-    """trading_state=normal と limits_state を commit で用意し、終了時に原状復帰する。"""
+    """trading_state=normal と limits_state を commit で用意し、終了時に原状復帰する。
+
+    **commit を伴う理由**: 本ファイルのテストは並行する2接続(c1/c2)から同じ帳簿の
+    ``gate_and_record`` を呼び、advisory lock の直列化を観測する。両接続から前提行
+    (``ops.trading_state`` / ``risk.limits_state``)が見える必要があるため、通常の
+    「1 テスト = 1 トランザクション」隔離では検証できず、autocommit 接続で **一時的に
+    commit** する。この commit は同一 DB を使う他テスト・他セッションに漏れうる。
+
+    **干渉し得る対象**:
+
+    - ``ops.trading_state`` は **singleton**(migrations/0007 の ``singleton BOOLEAN
+      PRIMARY KEY DEFAULT TRUE`` — 1 行制約)。テスト中に ``state='normal'`` に固定
+      するため、同時に走る他テストが別の値(``halted`` 等)を要求しているとどちらか
+      が落ちる。本フィクスチャが finally で ``prior_state`` に戻すことで、通常の
+      「連続実行」では干渉しないが、**並行実行**では復元前に他ワーカーが読むと崩れる。
+    - ``risk.limits_state`` の ``DEMO_FUND`` 行は追記(INSERT ... ON CONFLICT DO
+      NOTHING)。本フィクスチャが挿入前に存在しなかった場合のみ finally で削除する
+      ため、既存行は温存される。
+
+    **原状復帰の仕組み**: try/finally で ``prior_state`` / ``prior_limits`` を保存し、
+    テスト成功・失敗いずれの経路でも復元する。例外時も finally は実行される(pytest の
+    fixture teardown 契約)。それでも並行実行では復元前の隙間があるため、**このファ
+    イルは ``commits_shared_state`` マーカーで直列化対象として印字してある**。
+    """
     admin = connect(autocommit=True)
     with admin.cursor() as cur:
         cur.execute("SELECT state FROM ops.trading_state")

--- a/tests/gate/test_turnover_breach.py
+++ b/tests/gate/test_turnover_breach.py
@@ -1,0 +1,209 @@
+"""F-12 事後監視: 約定ベース売買代金の G-7 上限跨ぎ検知。
+
+``turnover_breach_after_execution`` はゲート判定時に固定した NAV(gate_log.state_ref)
+を上限計算に使い、当該約定を含めた累計が上限を跨いだ瞬間だけを ``TurnoverBreach`` で
+返す(エッジトリガ — 超過継続中の追加約定では鳴らさない)。NAV が取れない異常系は
+fail-closed で urgent 側に倒す。テストは commit せず rollback で隔離する。
+
+累計側のデータは ``trading.executions`` を SQL で直接複数投入して作る:
+``record_execution`` は「累計約定 ≤ 注文数量」制約を持つため、G-3/G-8 の集中度・
+レバ制約を通しつつ NAV×30% を跨ぐような大きな累計を単一注文経由で作れないため。
+検知ヘルパは executions の合算式のみを見るので、直接 INSERT でも意味論は同一。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, time, timedelta
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from ryza.gate.orders import gate_and_record, turnover_breach_after_execution
+from ryza.ips import load_and_validate
+
+from .conftest import jp_stock_proposal
+
+_JST = ZoneInfo("Asia/Tokyo")
+_NAV = Decimal(10_000_000)
+_CASH = Decimal(5_000_000)
+
+
+@pytest.fixture(autouse=True)
+def _normal_trading_state(conn):
+    """取引状態を normal に初期化(G-0 は行欠落を fail-closed で block するため)。"""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO ops.trading_state (state, updated_by) VALUES ('normal', 'test')
+            ON CONFLICT (singleton) DO UPDATE SET state = 'normal', updated_by = 'test'
+            """
+        )
+
+
+@pytest.fixture(scope="session")
+def turnover_limit_frac():
+    """発効 IPS の daily_turnover_nav_max(NAV 比)を取得。"""
+    ips, _ = load_and_validate()
+    return Decimal(str(ips.hard_limits.daily_turnover_nav_max))
+
+
+def _pass_order(conn, run_id, *, qty=Decimal(10)) -> int:
+    """ゲート通過注文を作り order_id を返す(累計は SQL で別途積む)。"""
+    order_id, _, result = gate_and_record(
+        conn,
+        jp_stock_proposal(qty=qty, ref_price=Decimal(1000)),
+        nav=_NAV,
+        cash=_CASH,
+        run_id=run_id,
+    )
+    assert result.verdict in ("pass", "warn"), result.reasons
+    return order_id
+
+
+def _insert_execution(
+    conn, *, order_id: int, qty: Decimal, price: Decimal, run_id: int, executed_at=None
+) -> int:
+    """``trading.executions`` に直接 INSERT して execution_id を返す。
+
+    検知ヘルパは executions 側の合算のみを見る(注文の累積制約は見ない)ため、
+    テスト用に累計を作るのは直接 INSERT で十分。JST 大引け相当を既定時刻とする。
+    """
+    if executed_at is None:
+        today = datetime.now(UTC).astimezone(_JST).date()
+        executed_at = datetime.combine(today, time(15, 30), tzinfo=_JST).astimezone(UTC)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO trading.executions
+                (order_id, qty, price, fee, executed_at, venue, broker_ref, run_id)
+            VALUES (%s, %s, %s, 0, %s, 'demo', NULL, %s)
+            RETURNING id
+            """,
+            (order_id, qty, price, executed_at, run_id),
+        )
+        return cur.fetchone()[0]
+
+
+def test_edge_trigger_fires_once_on_crossing(conn, run_id, limits_row, turnover_limit_frac):
+    """(a) before ≤ limit < after のエッジで検知1件、通知フィールドに数値が入る。"""
+    limits_row()
+    limit = turnover_limit_frac * _NAV  # NAV × 30% = ¥3,000,000
+    order_id = _pass_order(conn, run_id)
+    # 1件目: 上限手前まで積む(枠内)。
+    first_notional = limit - Decimal(100_000)
+    exec1 = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(1000),
+        price=first_notional / Decimal(1000), run_id=run_id,
+    )
+    assert turnover_breach_after_execution(conn, exec1) is None  # まだ枠内
+    # 2件目: 上限を跨ぐ(¥200,000 追加で¥3,100,000)。
+    exec2 = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(200), price=Decimal(1000), run_id=run_id,
+    )
+    breach = turnover_breach_after_execution(conn, exec2)
+    assert breach is not None
+    assert breach.execution_id == exec2
+    assert breach.before == first_notional
+    assert breach.after == first_notional + Decimal(200_000)
+    assert breach.limit == limit
+    assert breach.nav == _NAV
+    assert breach.nav_missing_reason is None
+    assert breach.nav_source_gate_log_id is not None
+    assert breach.book_id == "DEMO_FUND"
+
+
+def test_no_alarm_while_already_over_limit(conn, run_id, limits_row, turnover_limit_frac):
+    """(b) 既に超過中の追加約定では鳴らさない(after > limit だが before > limit)。
+
+    ゲートは注文時価格で判定するため、事後累計が既に上限を超えている状態でも新規注文
+    自体は「注文時基準では枠内」の局面がありうる(スリッページ次第)。エッジトリガの
+    継続鳴動抑止(通知が毎回赤だと意味を失う)を固定する。
+    """
+    limits_row()
+    limit = turnover_limit_frac * _NAV
+    order_id = _pass_order(conn, run_id)
+    # 1件目で一気に上限を跨がせる(before=0, after > limit)。
+    exec1 = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(4000), price=Decimal(1000), run_id=run_id,
+    )
+    first_breach = turnover_breach_after_execution(conn, exec1)
+    assert first_breach is not None  # 最初の跨ぎは鳴る
+    assert first_breach.after > limit
+    # 追加約定: before は既に上限超え → after も上限超えだが「跨ぎ」ではない。
+    exec2 = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(100), price=Decimal(1000), run_id=run_id,
+    )
+    assert turnover_breach_after_execution(conn, exec2) is None
+
+
+def test_within_limit_returns_none(conn, run_id, limits_row):
+    """(c) after ≤ limit の枠内なら None(通知しない)。"""
+    limits_row()
+    order_id = _pass_order(conn, run_id)
+    execution_id = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(100), price=Decimal(1000), run_id=run_id,
+    )
+    assert turnover_breach_after_execution(conn, execution_id) is None
+
+
+def test_fail_closed_when_gate_log_state_ref_lacks_nav(conn, run_id, limits_row):
+    """(d) gate_log.state_ref から NAV を取れない異常系は fail-closed で TurnoverBreach を返す。
+
+    ヘルパが呼び出し側にイベントを渡さない=通知が消える経路を作らないための不変性。
+    実運用では state_ref に nav は必ず入るが、ここでは検知の fail-closed 姿勢を固定する。
+    """
+    limits_row()
+    order_id = _pass_order(conn, run_id)
+    execution_id = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(100), price=Decimal(1000), run_id=run_id,
+    )
+    # gate_log は追記オンリー(監査証跡)だが、fail-closed 経路の検証にはスナップ
+    # ショットの nav 欠落を作る必要がある。**この1テストに限り**追記オンリーの
+    # BEFORE UPDATE トリガを一時的に外して state_ref から nav キーを取り除く
+    # (DDL はトランザクション内で巻き戻る)。実装が実運用でこの経路に到達する
+    # のは apply_execution が「gate_log を持たない約定」を弾く前段で state_ref が
+    # 壊れている異常系のみで、そのとき fail-closed で TurnoverBreach を返すことを
+    # 固定する。
+    with conn.cursor() as cur:
+        cur.execute(
+            "ALTER TABLE compliance.gate_log DISABLE TRIGGER gate_log_no_mutation"
+        )
+        cur.execute(
+            """
+            UPDATE compliance.gate_log g
+            SET state_ref = g.state_ref - 'nav'
+            FROM trading.orders o
+            WHERE o.id = %s AND g.id = o.gate_log_id
+            """,
+            (order_id,),
+        )
+        cur.execute(
+            "ALTER TABLE compliance.gate_log ENABLE TRIGGER gate_log_no_mutation"
+        )
+    breach = turnover_breach_after_execution(conn, execution_id)
+    assert breach is not None
+    assert breach.nav is None
+    assert breach.nav_missing_reason and "nav" in breach.nav_missing_reason
+    assert breach.after == Decimal(100_000)  # 累計は取れている(判定不能なのは上限)
+
+
+def test_trade_date_scoped_by_jst(conn, run_id, limits_row, turnover_limit_frac):
+    """JST 日付境界: 前日の約定は当日累計に入らない(``_daily_turnover`` と同じ規約)。"""
+    limits_row()
+    order_id = _pass_order(conn, run_id)
+    yesterday = datetime.now(UTC).astimezone(_JST).date() - timedelta(days=1)
+    yesterday_close = datetime.combine(yesterday, time(15, 30), tzinfo=_JST).astimezone(UTC)
+
+    # 前日約定で上限相当を積む(当日の累計には入らない)。
+    limit = turnover_limit_frac * _NAV
+    _insert_execution(
+        conn, order_id=order_id, qty=Decimal(3000),
+        price=limit / Decimal(3000), run_id=run_id, executed_at=yesterday_close,
+    )
+    # 当日約定: 単独で枠内(¥100,000)。前日分を含めれば超過だが、日付で切られる。
+    exec_today = _insert_execution(
+        conn, order_id=order_id, qty=Decimal(100), price=Decimal(1000), run_id=run_id,
+    )
+    breach = turnover_breach_after_execution(conn, exec_today)
+    assert breach is None  # 当日累計は¥100,000 のみ → 枠内

--- a/tests/risk/test_daily.py
+++ b/tests/risk/test_daily.py
@@ -238,6 +238,82 @@ def test_load_nav_series_pending_flow_after_last_snapshot(conn, run_id):
     ]
 
 
+def test_f14a_future_entry_date_goes_to_pending(conn, run_id):
+    """F-14a 異常系(1): 系列最終日より**未来**の entry_date は points に混入せず pending へ。
+
+    ``pending_flows_after_last_snapshot`` の意味論を **F-14a リグレッション固定**として明示。
+    仕訳日が測定系列の外(未来側)に落ちる場合、その額を **黙って points に混ぜる**
+    (= 直近スナップショットのフロー扱いにする)経路が復活しないことを固定する
+    (Issue #124 pass5-2 の是正点 — 「黙って落とさない/黙って混ぜない」)。
+    """
+    _clear_nav(conn)
+    _seed_nav_days(conn, {date(2030, 1, 2): 1_000_000, date(2030, 1, 5): 1_000_000})
+    before = _net_flows(conn)
+    future_amount = Decimal(500_000)
+    _seed_capital_flow(conn, run_id, amount=int(future_amount), entry_date=date(2030, 1, 6))
+    loaded = load_nav_series(conn, "DEMO_FUND")
+    # points に混入していない: 各点の net_flow は仕訳前と同一。
+    assert {p.day: p.net_flow for p in loaded.points} == before
+    # pending に現れる。
+    assert [(p.entry_date, p.amount) for p in loaded.pending_flows] == [
+        (date(2030, 1, 6), future_amount)
+    ]
+
+
+def test_f14a_entry_before_series_start_attaches_to_first_point(conn, run_id):
+    """F-14a 異常系(2): 系列開始より**過去**の entry_date は先頭点に寄る(現行挙動の固定)。
+
+    「その日以降の最初の snap_date」の規約(``NAV_FLOW_SQL`` `attributed` CTE)に従い、
+    測定系列の始点より前の仕訳も**捨てずに**先頭点へ帰属させる — 帰属先の snap_date が
+    存在するため pending にはならない。**この経路が「黙って消える」に退化しないこと**を
+    F-14a として固定する(Issue #124 pass5-2 の是正点)。実測経路が既に固定されている
+    テスト(``test_load_nav_series_flow_before_series_start``)と同じ挙動を、**pending
+    に紛れ込まない**ことの検証と組み合わせて多重に留める。
+    """
+    _clear_nav(conn)
+    _seed_nav_days(conn, {date(2030, 1, 5): 1_000_000, date(2030, 1, 6): 1_100_000})
+    before = _net_flows(conn)
+    past_amount = Decimal(400_000)
+    _seed_capital_flow(conn, run_id, amount=int(past_amount), entry_date=date(2030, 1, 1))
+    loaded = load_nav_series(conn, "DEMO_FUND")
+    # 先頭点に BOP/EOP のいずれかで寄る(現行実装は当日仕訳=EOP・以前=BOP)。
+    assert loaded.points[0].net_flow - before[date(2030, 1, 5)] == past_amount
+    # pending には出ない(帰属できる snap_date があるため)。
+    assert loaded.pending_flows == ()
+
+
+def test_f14a_sum_preservation_across_anomalies(conn, run_id):
+    """F-14a 異常系(3): 系列先頭より過去+最終より未来のフローがあっても**合計が保存**される。
+
+    F-14a リグレッション固定の総和不変量(Issue #124 pass5-2):
+    ``sum(points[i].net_flow) + sum(pending.amount)`` は投入したフロー総額に等しい。
+    先頭より前を「黙って落とす」経路や、最終より後を points に紛れ込ませて二重計上する
+    経路(どちらも歴史的なバグの典型)を、単一の総和 assert で同時に塞ぐ。
+
+    先頭点にはシード(0006/0011)由来の開始仕訳が寄るため、テストは投入前後の**増分**で
+    判定する。
+    """
+    _clear_nav(conn)
+    _seed_nav_days(conn, {date(2030, 1, 5): 1_000_000, date(2030, 1, 6): 1_100_000})
+    before = load_nav_series(conn, "DEMO_FUND")
+    before_total = sum((p.net_flow for p in before.points), start=Decimal(0)) + sum(
+        (p.amount for p in before.pending_flows), start=Decimal(0)
+    )
+    injected = [
+        (date(2030, 1, 1), Decimal(400_000)),   # 系列先頭より過去
+        (date(2030, 1, 5), Decimal(150_000)),   # 系列内(当日)
+        (date(2030, 1, 8), Decimal(-200_000)),  # 系列最終より未来(払戻)
+    ]
+    for d, amt in injected:
+        _seed_capital_flow(conn, run_id, amount=int(amt), entry_date=d)
+    after = load_nav_series(conn, "DEMO_FUND")
+    after_total = sum((p.net_flow for p in after.points), start=Decimal(0)) + sum(
+        (p.amount for p in after.pending_flows), start=Decimal(0)
+    )
+    expected = sum((amt for _, amt in injected), start=Decimal(0))
+    assert after_total - before_total == expected
+
+
 def test_run_risk_daily_reports_pending_flow(conn, run_id):
     """未反映フローは独立フィールドで注記し、締めを跨いでいれば urgent(重要-4・中-5)。"""
     _clear_nav(conn)


### PR DESCRIPTION
Closes #124(A-12 監査所見 F-12 / F-14 の是正 — Issue #15)

## Summary

- **F-12(G-7 TOCTOU)**: G-7 は注文時価格で事前評価するため、スリッページで約定額面が膨らむと約定後に枠超過が起こり得る。`turnover_breach_after_execution`(gate/orders.py)が約定ベースの当日累計を before/after で計算し、**跨いだ瞬間のみ**(`before ≤ limit < after` のエッジトリガ)`TurnoverBreach` を返す。執行ループ(execution/runner.py)が同一トランザクション内で #運営 へ urgent 通知(約定の巻き戻しと通知の存在が一致)。NAV はゲート判定時スナップショット(gate_log.state_ref)から取得し、取れない異常系は fail-closed で urgent(理由コード付き)
- **F-14a**: load_nav_series の異常タイムスタンプ挙動をリグレッション固定(未来仕訳→pending_flows / 系列開始前仕訳→最初のスナップに BOP 帰属〔実測で黙って消えないことを確認〕/ 合計フロー保存)
- **F-14b**: test_lock の commit を伴うフィクスチャに分離条件を明記+`commits_shared_state` マーカー登録
- G-7 本体のロジックは無変更(docstring に事後監視との構図を1行追記のみ)

## 仕様書からの逸脱(設計リード受容済み)

- 呼び出し箇所は仕様の demo.py でなく execution/runner.py(record_execution を呼ぶのは runner — 仕様の前提誤り)
- NAV の出所は order_ref でなく gate_log.state_ref(実装の実経路に一致)

## 検証(設計リード検分)

- F-12 新テスト 5/5 通過(実 DB・rollback 隔離)、tests/gate 66 passed
- tests/risk/test_daily・tests/execution/test_close の失敗は main でも同一再現(共有 DB 残留による既存の環境要因)— CI のクリーン DB が最終判定
- 検分で embed の「× 30%」ハードコードを是正(e27cf19 — 受け入れ基準「IPS 値のハードコード禁止」)

## Test plan

- [x] F-12: エッジ検知/超過継続中は鳴らない/枠内 None/NAV 欠落 fail-closed/JST 日付境界
- [x] F-14a: 未来仕訳・過去仕訳・合計保存
- [ ] CI(クリーン DB)で全スイート通過
- [ ] 保護領域(ゲート・執行)につき独立役員審査 → みなし承認記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)