### PR TITLE
feat(ingest): T-030 J-Quants 財務諸表の daily 配線+バックフィル CLI

### DIFF
--- a/docs/reviews/t030-statements-review.md
+++ b/docs/reviews/t030-statements-review.md
@@ -1,0 +1,61 @@
+---
+review: t030-jquants-statements
+reviewed_sha: 4e5b7bf3bd5a02872f61a3d27862f9961f2d1e1d
+reviewer: 独立役員(プロンプト分離)
+review_date: 2026-08-04
+verdict: approve
+---
+
+# T-030 審査意見書: J-Quants 財務諸表の daily 配線+バックフィル CLI(PR #148)
+
+**アーギュメント**: 本 PR は指示書 T-030 の §1〜§5 を全項目満たし(daily 後段配線・実効日共用・失敗分離・平日限定バックフィル・冪等・sleep 根拠コメント・`daily.py`/既存関数の不変更)、テストは値レベルの実質的アサーションを持ちローカル共有 DB で 26/26 通過・CI green であるため **approve** とする — ただし statements 失敗が stdout の 1 行にしか現れず機械可読な監視面(daily ジョブの per_source status・meta.runs status)では success のままになる観測性の弱さが 1 件(中)あり、フォローアップ起票を推奨する。
+
+## 検証方法
+
+- worktree `/tmp/t030-review`(detached 4e5b7bf)で `git diff origin/main...HEAD` を精査。変更は指示書 §3 の 3 ファイルのみ(jquants.py +141/-11、test_jquants.py +156/-1、タスク文書新規)。スコープ外変更なし
+- テスト実行(共有 DB・1回): `tests/ingest/test_jquants.py` — **26 passed, 89.56s**。失敗なし(Issue #142 の既知失敗一覧を参照する必要なし)
+- CI: PR #148 の required check `test` は pass(GitHub Actions run 30913029032)
+
+## 指示書との合致(§1〜§5)
+
+| 要求 | 判定 | 根拠 |
+|---|---|---|
+| §1 日足の後段で statements 取得 | 合致 | run_daily 内で bars 取込(jquants.py:335-339)の後に fetch_statements → ingest_statements(jquants.py:340-346) |
+| §1 実効日 = effective_quote_date 共用・--lag-days 共用 | 合致 | main が丸め済み quote_date を run_daily に渡し(jquants.py:470-481)、statements も同じ quote_date で叩く(jquants.py:343)。テストが URL の date パラメータで直接検証(test_jquants.py:371-395) |
+| §1 DailyResult.statements+実行サマリ | 合致 | フィールド追加(jquants.py:310)、main の print に DailyResult 全体が載る(jquants.py:482)。成功時 `{'written','total'}`/失敗時 `{'error':型名+メッセージ}` の判別可能な形 |
+| §1 失敗分離(日足を巻き添えにしない) | 合致 | try/except で捕捉し error 記録(jquants.py:342-346)。テストは日足 written=1 維持+DB 実在+error 記録を値でアサート(test_jquants.py:279-303) |
+| §2 バックフィル CLI(両方指定時のみ・両端含む・平日のみ) | 合致 | `--backfill-statements-from/to`(jquants.py:437-444)、両方指定時のみ発動(jquants.py:453)、`_weekday_range` は両端含む inclusive ループ+weekday<5(jquants.py:363-376)。off-by-one なし: テストが 2026-05-01(金)〜05-08(金)で平日 6 日・土日不呼び出しを URL レベルで検証(test_jquants.py:323-346) |
+| §2 冪等 | 合致 | ingest_statements の DiscDate+DiscNo キーをそのまま利用。再実行 written=0 を値でアサート(test_jquants.py:349-363) |
+| §2 sleep+根拠コメント | 合致 | `_BACKFILL_SLEEP_SEC = 1.0`、Free プランの公表レートリミット不在(2026-08-04 時点)を根拠に保守的 1 秒とするコメント(jquants.py:352-357)— 指示書 §2「確認できなければ保守的に 1 秒程度」の指定どおり |
+| §2 進捗ログ+合計サマリ | 合致 | 20 日ごと+最終日に 1 行(jquants.py:411-415)、終了時 `{days, written, total}`(jquants.py:418, 461-463) |
+| §2 バックフィル未実行のまま PR | 合致 | docs.documents の J-Quants financial_statement は依然 0 件前提(タスク文書記載)。PR に実行痕跡なし |
+| §3 daily.py 不変更・既存 2 関数不変更 | 合致 | diff は 3 ファイルのみ。fetch_statements(jquants.py:247-256)・ingest_statements(jquants.py:259-296)への diff ハンクなし |
+| §4 テスト 4 項目 | 合致 | 配線(test_jquants.py:251-276)・失敗分離(:279-303)・バックフィル平日/冪等/サマリ(:323-363)・実効日伝播(:371-395)。すべて具体値のアサーション |
+| §5 CI green | 合致 | required check pass(上記) |
+
+**テストの実質性**: モック(FakeFetcher, tests/ingest/conftest.py:54-95)は URL 部分一致+呼び出し履歴の素直な実装で、実装に都合よく歪んでいない。特にバックフィルの平日判定は「呼び出し回数=6」と「date=2026-05-02/03 が URL に混入しない」の二重検証(test_jquants.py:342-346)、冪等は r1/r2 の dict 全体一致(test_jquants.py:361-363)、失敗分離は DB の bars 実在まで確認(test_jquants.py:297-303)と、値ベースで堅い。`--no-statements` 相当のスキップも fins/summary 不呼び出しを履歴で検証(test_jquants.py:306-320)— これは指示書反対意見書 §6-2 の「実装してよい・必須ではない」に該当し、過剰実装ではない。
+
+## 所見
+
+### 重大: なし
+
+### 中(1件)
+
+1. **statements 失敗が機械可読な監視面に現れない(stdout の print のみ)**。run_daily が例外を握って error を DailyResult に載せるため、jquants.main は statements 失敗時も 0 を返し(jquants.py:342-346, 476-485)、daily ジョブの per_source サマリは `status: ok, result: 0` になる(src/ryza/jobs/daily.py:198-208 — 例外送出のみが failed)。meta.runs の `ingest.jquants.daily` も success で終わる(src/ryza/provenance/runs.py:227-234)。観測手段は stdout の `print(f"jquants daily ...: {result}")`(jquants.py:482)のログ grep のみ。指示書 §1 が「終了コードは既存の流儀・daily.py に触れない」と明示している以上この設計は指示の範囲内であり approve を妨げないが、「静かに空回りさせない」の趣旨からは、Run.params への error 記録(Run に params パッチ機構あり: runs.py:150 付近)か週次チェックでの docs.documents 件数監視をフォローアップ起票すべき。
+
+### 軽微(4件)
+
+1. **except Exception の広さ**(jquants.py:345)。HTTP 失敗は RuntimeError(jquants.py:104)だが、捕捉は Exception 全体のため ingest_statements 内の実装バグ(TypeError 等)も同経路に飲まれる。例外型名込みで記録されるため無音ではないが、`(RuntimeError, psycopg.Error)` に絞ればバグとデータ源異常を区別できる。
+2. **バックフィルフラグの片方のみ指定時、警告なく日次モードへフォールバック**(jquants.py:453 の and 条件)。指示書 §2「両方指定されたときのみ」の文言どおりだが、片方だけ渡した operator は意図せず日次を回すことになる。片方のみなら parser.error が安全。
+3. **§4-4 テストの経路が main を通らない**。test_main_effective_date_applies_to_statements(test_jquants.py:371-395)は名前に main とあるが run_daily を直接呼ぶ。`--lag-days` → effective_quote_date → statements の end-to-end は「丸め自体の既存テスト(test_jquants.py:66-95)+quote_date 伝播の本テスト」の合成で分割検証されており論理的には被覆されるが、main の引数処理の結線そのものは未検証。
+4. **バックフィル中の 1 日の失敗で全体が中断し、部分サマリが出ない**(jquants.py:401-417 — run_ctx が failed を記録して再送出、合計 print に到達しない)。冪等なので再実行で回復可能であり指示書も失敗許容を要求していないが、数百日運用ではどこまで進んだかが進捗ログ頼みになる。
+
+## 反対意見書(この approve 判定が間違っている場合の理由トップ3)
+
+1. **中所見 1 は request_changes に値する** — 監視の実効性こそ本タスクの核心(「静かに空回りさせない」)であり、stdout print は Cloud Run/VM のログ保持・確認運用に依存する脆い観測面。statements が毎日 403 で空回りしても daily サマリは全 ok で並ぶ。*反論*: 指示書 §1 が exit code の流儀維持と daily.py 不変更を明示指定しており、実装は指示に忠実。観測面の強化は指示書の改訂(=設計リードの判断)を要する事項で、実装 PR の差し戻し理由にするのは審査対象の取り違え。*代替案*: approve のまま、マージ後の初回実走(バックフィル前の 1 回)で DailyResult.statements の実値をログ確認する運用手順を完了報告に含めさせる。
+2. **Free プランで /v2/fins/summary が取得可能かが未確認のまま配線している** — 指示書 §6-3 が自認するとおり、403/400 なら本配線は恒久的な空回りで、テストは全モックのためこのリスクを一切検出しない。*反論*: fail-closed(データが増えないだけ)であり、日足と同じ 12 週丸め済み日付を使うためプラン範囲外 400 の主因(直近日付)は回避済み。マージ後に設計リードが行うバックフィルが事実上の実 API 検証を兼ねる。*代替案*: バックフィル実行を「まず 1 週間ぶんの試走→サマリ確認→全範囲」の 2 段にする(CLI は日付範囲指定なので追加実装不要)。
+3. **祝日を叩く無駄と、_weekday_range の反転レンジ挙動の非対称** — 祝日(例: テストが使う 2026-05-04〜06 は GW)にも API を叩き、また run_backfill_statements を反転レンジで直接呼ぶと黙って `{days: 0}` を返す(検査は CLI 層のみ: jquants.py:456-457)。*反論*: 祝日除外の不採用は effective_quote_date と同一の明示的設計判断(取引カレンダー依存を持ち込まない: jquants.py:367-368)で、空応答+1 秒 sleep のコストは無視できる。反転レンジの黙殺は「呼び出しゼロ」という無害側に倒れており、公開経路(CLI)では parser.error で防いでいる。*代替案*: 現状維持。ライブラリ関数として他所から呼ばれ始めたら ValueError 化を起案する。
+
+## 結論
+
+verdict: **approve**。指示書の全受け入れ基準を満たし、テストは実質的、スコープ逸脱なし。中所見 1(statements 失敗の機械可読な観測面)のフォローアップ起票を条件ではなく推奨として付す。

--- a/docs/tasks/T-030-jquants-statements-wiring.md
+++ b/docs/tasks/T-030-jquants-statements-wiring.md
@@ -1,0 +1,58 @@
+# T-030: J-Quants 財務諸表取込の daily 配線+日付範囲バックフィル
+
+**アーギュメント**: `src/ryza/ingest/jquants.py` の `ingest_statements` / `fetch_statements` は実装済みだが**どこからも呼ばれておらず**(run_daily は銘柄マスタ+日足のみ)、DB には財務諸表文書が 0 件のまま — T-029(financial サマリの数値昇格)と T-019(Peter=GARP)の前提が空転しているので、本タスクは statements 取得を日次経路に配線し、過去分を日付範囲バックフィルで埋める。
+
+## 目的と背景(自己完結)
+
+- `jquants.run_daily`(src/ryza/ingest/jquants.py)は `ingest_instruments` と `ingest_daily_quotes` のみを実行する。財務(`/v2/fins/summary`)の取得・取込関数(`fetch_statements` / `ingest_statements`)は同ファイルに実装済み・テスト済みだが未配線
+- 確認事実(2026-08-04): `docs.documents` に source_name='J-Quants' かつ kind='financial_statement' の行は 0 件、`ledger.evidence` に kind='jquants_statement' は 0 件
+- 下流: T-029(`src/ryza/preprocess/fundamentals.py` — PR #147)が statements 文書を `market.indicators` へ昇格する。取込が無ければ昇格対象も無い
+
+## 1. daily 配線
+
+- `run_daily` に statements 取得ステップを追加する: `fetch_statements(fetcher, key, stmt_date=<実効日>)` → `ingest_statements(...)`
+- **実効日は `effective_quote_date` を再利用**(Issue #38 の Free プラン 12 週遅延の丸め+土日繰り下げ)。財務データにも同じプラン遅延が適用されるため、日足と同じ丸めでよい。`lag_days` は既存の `--lag-days` 引数を共用する
+- `DailyResult` に `statements: dict[str, int]` を追加し、`main` の実行サマリ出力にも載せる(静かに空回りさせない — 取込 0 件が観測できること)
+- statements 取得の失敗(HTTP エラー)は**日足取込を巻き添えにしない**: 日足の後に実行し、例外は捕捉してサマリに `error` として記録、終了コードは既存の流儀に従う(他ソースの部分失敗の扱い — `src/ryza/jobs/daily.py` の呼び出し側がどう扱うか確認して整合させること)
+
+## 2. 日付範囲バックフィル
+
+- `main` に `--backfill-statements-from YYYY-MM-DD` / `--backfill-statements-to YYYY-MM-DD` を追加(両方指定されたときのみバックフィルモード)
+- from→to の**平日のみ**を日次で `fetch_statements(stmt_date=...)` → `ingest_statements` する。開示が無い日は空リストが返るだけ(エラーにならない)
+- 冪等: `ingest_statements` の冪等キー(DiscDate+DiscNo)で再実行安全(既存実装のまま)
+- レート制限への配慮: 呼び出し間に小さな sleep(値は定数で持ち、根拠コメントを書く。J-Quants の公表レート制限を確認し、確認できなければ保守的に 1 秒程度)
+- 進捗は 20〜30 日ごとに 1 行のログ(数百日を無言で回さない)。終了時に合計(処理日数・written・total)を出す
+- **バックフィル自体はこのタスクで実行しない**(マージ後に設計リードが行う)。CLI を作るところまで
+
+## 3. 実装物の一覧
+
+| # | パス | 内容 |
+|---|---|---|
+| 1 | `src/ryza/ingest/jquants.py` | run_daily への statements 配線+バックフィル CLI |
+| 2 | `tests/ingest/test_jquants.py` | 下記 §4 の追加テスト |
+| 3 | `docs/tasks/T-030-jquants-statements-wiring.md` | 本仕様書(そのままコミット) |
+
+新規モジュール・スキーマ変更・保護領域なし。`src/ryza/jobs/daily.py` には触れない(jquants.main の内側で完結させる)。
+
+## 4. テスト(tests/ingest/test_jquants.py に追加)
+
+既存のモック Fetcher パターンに従う:
+
+1. run_daily が statements を取得・取込し、結果が DailyResult.statements に載る
+2. statements の HTTP エラーが日足取込の成功を巻き添えにしない(日足 written は維持され、statements はエラーとして記録される)
+3. バックフィル: 3〜5 日ぶんのモックで平日のみ処理・冪等(再実行で written 0)・合計サマリ
+4. 実効日の丸めが statements にも適用される(lag_days の反映)
+
+## 5. 受け入れ基準
+
+1. CI green
+2. §4 のテストが存在し実質的なアサーションを持つ
+3. sleep 値・丸めの根拠コメント
+4. 既存の `fetch_statements` / `ingest_statements` を変更しない(呼ぶだけ。変更が必要になったら理由を完了報告に書く)
+5. バックフィルは未実行のまま PR(実行は設計リード)
+
+## 6. 反対意見書(この指示が間違っている場合の理由トップ3)
+
+1. **日次で date 指定取得だと、遅延丸めで同じ開示を何度も見に行く/取りこぼす境界がある** — 丸めが「今日−12週」に張り付くため、日次実行が1日ずつずれて全日をちょうど1回ずつ舐める前提が崩れると欠落日が出る。*反論*: 冪等キーがあるので重複は無害。欠落側はバックフィル CLI で任意範囲を再取得できる。*代替案*: 毎回「前回取得日から実効日まで」を範囲取得する方式 — 状態(前回取得日)の永続化が必要になり初版の複雑度が上がる。まず日次+手動バックフィルで運用し、欠落が観測されたら起案する
+2. **statements は日足と独立のジョブにすべき** — 失敗の分離・再実行の粒度から別 CLI が正しい。*反論*: §1 で失敗を分離しており、同一 API・同一認証・同一遅延丸めのソースを2ジョブに割る運用コストの方が高い。*代替案*: `--no-statements` フラグで無効化できるようにしておけば分離の余地は残る(実装してよい・必須ではない)
+3. **Free プランの提供範囲確認が先** — `/v2/fins/summary` が Free プランで取得可能かの確認なしに配線しても 403 で空回りする。*反論*: 空回りは §1 のサマリ記録で観測可能であり、fail-closed(データが増えないだけ)。プラン制約が判明したらリマインダー登録して対応する。*代替案*: 実装前に API を手で叩いて確認する — 認証情報は環境にあるので実装エージェントが1回試すのは許容(読み取りのみ)

--- a/src/ryza/ingest/jquants.py
+++ b/src/ryza/ingest/jquants.py
@@ -30,7 +30,8 @@ HTTP は ``Fetcher`` 越し（テストはモック）。日足の各バーは�
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
@@ -302,6 +303,11 @@ def ingest_statements(
 class DailyResult:
     instruments: dict[str, int]
     bars: dict[str, int]
+    # statements は日足の後段で取得する（Free プランでは日足と同じ 12 週遅延が適用され
+    # るため実効日は共有する）。取込 0 件が「本当に開示ゼロだった」か「取込段が例外で
+    # 空回りした」かをサマリで見分けるため、成功時は ``{'written', 'total'}``、失敗時は
+    # ``{'error': ...}`` を載せる（run_daily 内で完結：src/ryza/jobs/daily.py には触れない）。
+    statements: dict[str, Any] = field(default_factory=dict)
 
 
 def run_daily(
@@ -312,9 +318,16 @@ def run_daily(
     *,
     quote_date: str,
     with_instruments: bool = True,
+    with_statements: bool = True,
     key: str | None = None,
 ) -> DailyResult:
-    """日次取込（銘柄マスタ更新 + 当日日足）を実行する。"""
+    """日次取込（銘柄マスタ更新 + 当日日足 + 財務諸表）を実行する。
+
+    statements は日足の**後**に取得する。同一 API・同一プラン遅延・同一認証のため実効日
+    （``quote_date``）を共有するが、HTTP エラー等で失敗しても日足取込を巻き添えにしない
+    よう例外をここで捕捉し、``DailyResult.statements`` に ``{'error': ...}`` として記録する
+    （T-030 §1 の「静かに空回りさせない」）。``with_statements=False`` で無効化できる。
+    """
     key = key if key is not None else api_key()
     inst_result = {"resolved": 0, "created": 0}
     if with_instruments:
@@ -324,7 +337,85 @@ def run_daily(
         conn, run, store, quotes,
         quote_date=quote_date, raw_response=quotes,
     )
-    return DailyResult(instruments=inst_result, bars=bars_result)
+    stmt_result: dict[str, Any] = {}
+    if with_statements:
+        try:
+            statements = fetch_statements(fetcher, key, stmt_date=quote_date)
+            stmt_result = ingest_statements(conn, run, store, statements)
+        except Exception as exc:  # noqa: BLE001 - 日足取込を巻き添えにしない（T-030 §1）
+            stmt_result = {"error": f"{type(exc).__name__}: {exc}"}
+    return DailyResult(
+        instruments=inst_result, bars=bars_result, statements=stmt_result
+    )
+
+
+# バックフィル時の API 呼び出し間 sleep（秒）。J-Quants の公式レートリミット表は Free
+# プランでは明記されていない（2026-08-04 時点、jquants.com/pricing/）。境界越えで 429 を
+# 出すよりは保守的に **1 秒**の間を置き、他ジョブと同居して走らせても API 側に負荷を
+# 集中させない。数百日ぶんの呼び出しでも合計数分の増加に収まる（日単位のバックフィル
+# は運用上「たまに」流すもので、律速要因ではない）。
+_BACKFILL_SLEEP_SEC = 1.0
+
+# バックフィルの進捗ログを何日ごとに出すか。数百日を無言で回さない（T-030 §2）。
+_BACKFILL_PROGRESS_EVERY = 20
+
+
+def _weekday_range(start: date, end: date) -> list[date]:
+    """``start``〜``end``（両端含む）の平日のみを返す（土日はスキップ）。
+
+    J-Quants の ``date`` 指定は開示が無い日でも空データを返すためエラーにはならないが、
+    土日を叩く意味は無いため落とす（``effective_quote_date`` と同じ扱い）。祝日は
+    落とさない（取引カレンダー依存を持ち込まない）。
+    """
+    out: list[date] = []
+    d = start
+    while d <= end:
+        if d.weekday() < 5:  # 5=土, 6=日
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def run_backfill_statements(
+    conn: psycopg.Connection,
+    fetcher: Fetcher,
+    store: EvidenceStore,
+    *,
+    date_from: date,
+    date_to: date,
+    key: str | None = None,
+    sleep_sec: float = _BACKFILL_SLEEP_SEC,
+    progress_every: int = _BACKFILL_PROGRESS_EVERY,
+) -> dict[str, int]:
+    """日付範囲の財務諸表をバックフィルする（平日のみ・冪等・レート配慮）。
+
+    ``date_from`` から ``date_to`` の**平日**を日次で ``/v2/fins/summary`` に叩き、
+    ``ingest_statements`` へ流す。開示が無い日は空リストが返る（エラーにならない）。
+    冪等キー（``DiscDate+DiscNo``）は ``ingest_statements`` 側で担保されているので再実行
+    安全（既存分は written=0）。返り値は ``{days, written, total}``。
+    """
+    key = key if key is not None else api_key()
+    days = _weekday_range(date_from, date_to)
+    total_written = 0
+    total_seen = 0
+    for i, d in enumerate(days, start=1):
+        iso = d.isoformat()
+        with run_ctx(
+            "ingest.jquants.backfill_statements",
+            {"date": iso}, conn=conn,
+        ) as r:
+            statements = fetch_statements(fetcher, key, stmt_date=iso)
+            res = ingest_statements(conn, r, store, statements)
+        total_written += res["written"]
+        total_seen += res["total"]
+        if i % progress_every == 0 or i == len(days):
+            print(
+                f"jquants backfill_statements 進捗 {i}/{len(days)} "
+                f"最終日={iso} written+={res['written']} total+={res['total']}"
+            )
+        if i < len(days) and sleep_sec > 0:
+            time.sleep(sleep_sec)
+    return {"days": len(days), "written": total_written, "total": total_seen}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -336,27 +427,57 @@ def main(argv: list[str] | None = None) -> int:
         "--no-instruments", action="store_true", help="銘柄マスタ更新を省略"
     )
     parser.add_argument(
+        "--no-statements", action="store_true",
+        help="財務諸表取込を省略（日足と切り離したいとき）",
+    )
+    parser.add_argument(
         "--lag-days", type=int, default=_PLAN_LAG_DAYS,
         help=f"プラン遅延日数（既定 {_PLAN_LAG_DAYS}=Free。有償プランは 0）",
     )
+    parser.add_argument(
+        "--backfill-statements-from", default=None,
+        help="財務諸表バックフィル開始日 YYYY-MM-DD（--to と併用でバックフィルモード）",
+    )
+    parser.add_argument(
+        "--backfill-statements-to", default=None,
+        help="財務諸表バックフィル終了日 YYYY-MM-DD（両端含む・平日のみ処理）",
+    )
     args = parser.parse_args(argv)
-
-    # Free プランは直近 12 週の日付指定が HTTP 400 になるため、取得可能な日付へ丸める
-    # （モジュール docstring / Issue #38）。
-    quote_date = effective_quote_date(
-        date.fromisoformat(args.date), lag_days=args.lag_days
-    ).isoformat()
 
     store = base.default_store()
     fetcher = base.default_fetcher()
     # autocommit 共有接続: 冪等な追記書込は逐次確定でよい（再実行が続きを埋める）。
     conn = connect(autocommit=True)
     try:
+        # ── バックフィルモード（両方指定されたときのみ） ──────────────────────
+        if args.backfill_statements_from and args.backfill_statements_to:
+            date_from = date.fromisoformat(args.backfill_statements_from)
+            date_to = date.fromisoformat(args.backfill_statements_to)
+            if date_from > date_to:
+                parser.error("--backfill-statements-from は --backfill-statements-to 以前")
+            summary = run_backfill_statements(
+                conn, fetcher, store, date_from=date_from, date_to=date_to,
+            )
+            print(
+                f"jquants backfill_statements {date_from}〜{date_to}: {summary}"
+            )
+            return 0
+
+        # ── 通常の日次モード ─────────────────────────────────────────────────
+        # Free プランは直近 12 週の日付指定が HTTP 400 になるため、取得可能な日付へ丸める
+        # （モジュール docstring / Issue #38）。財務データも同じプラン遅延の対象なので
+        # 実効日を共有する（T-030 §1）。
+        quote_date = effective_quote_date(
+            date.fromisoformat(args.date), lag_days=args.lag_days
+        ).isoformat()
+
         params = {"date": args.date, "effective_date": quote_date}
         with run_ctx("ingest.jquants.daily", params, conn=conn) as r:
             result = run_daily(
                 conn, r, store, fetcher,
-                quote_date=quote_date, with_instruments=not args.no_instruments,
+                quote_date=quote_date,
+                with_instruments=not args.no_instruments,
+                with_statements=not args.no_statements,
             )
         print(f"jquants daily {quote_date} (要求 {args.date}): {result}")
     finally:

--- a/tests/ingest/test_jquants.py
+++ b/tests/ingest/test_jquants.py
@@ -1,7 +1,8 @@
 """J-Quants V2 取込テスト（HTTP 全モック）。
 
 正常系（API キー→日足→bars 書込・SCD2・証憑・リネージ）・重複（冪等）・
-認証（API キー未設定）・ページネーション。
+認証（API キー未設定）・ページネーション、statements の daily 配線・失敗分離・
+日付範囲バックフィル（T-030）。
 """
 
 from __future__ import annotations
@@ -232,11 +233,164 @@ def test_run_daily_full_flow(conn, run, store, fetcher):
         status=200,
         body=b'{"data": [{"Code":"72030","O":1,"H":2,"L":1,"C":2,"Vo":10}]}',
     ))
+    # T-030: statements も日足と同じ実効日で取得する。全ルート登録の完全系。
+    fetcher.add("fins/summary", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","DiscDate":"2026-08-03",'
+             b'"DiscNo":"20260803001","DocType":"FYFinancialStatements"}]}',
+    ))
     result = jquants.run_daily(
         conn, run, store, fetcher, quote_date="2026-08-03", key="KEY123"
     )
     assert result.bars["written"] == 1
     assert result.instruments["resolved"] == 1
+    assert result.statements == {"written": 1, "total": 1}
+
+
+# ── T-030: statements の daily 配線・失敗分離・バックフィル ─────────────────
+def test_run_daily_writes_statements_alongside_bars(conn, run, store, fetcher):
+    """run_daily が statements も取得・取込し DailyResult.statements に載せる。"""
+    fetcher.add("equities/bars/daily", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","O":1,"H":2,"L":1,"C":2,"Vo":10}]}',
+    ))
+    fetcher.add("fins/summary", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","DiscDate":"2026-08-03",'
+             b'"DiscNo":"D1","DocType":"FYFinancialStatements"},'
+             b'{"Code":"67580","DiscDate":"2026-08-03",'
+             b'"DiscNo":"D2","DocType":"FYFinancialStatements"}]}',
+    ))
+    result = jquants.run_daily(
+        conn, run, store, fetcher,
+        quote_date="2026-08-03", with_instruments=False, key="KEY123",
+    )
+    assert result.bars["written"] == 1
+    assert result.statements == {"written": 2, "total": 2}
+    # DB にも docs.documents（source_name='J-Quants'）が 2 件書かれている。
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM docs.documents "
+            "WHERE source_name='J-Quants' AND meta->>'kind'='financial_statement'"
+        )
+        assert cur.fetchone()[0] == 2
+
+
+def test_run_daily_statements_error_does_not_break_bars(conn, run, store, fetcher):
+    """statements の HTTP エラーが日足取込の成功を巻き添えにしない（T-030 §1）。"""
+    fetcher.add("equities/bars/daily", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","O":1,"H":2,"L":1,"C":2,"Vo":10}]}',
+    ))
+    fetcher.add("fins/summary", FetchResult(
+        status=500, body=b'{"message": "boom"}',
+    ))
+    result = jquants.run_daily(
+        conn, run, store, fetcher,
+        quote_date="2026-08-03", with_instruments=False, key="KEY123",
+    )
+    # 日足は書けている。
+    assert result.bars["written"] == 1
+    # statements はエラーとして記録される（例外は上には伝播しない）。
+    assert "error" in result.statements
+    assert "500" in result.statements["error"]
+    # 日足の書き込みは実在する（statements 失敗で巻き戻っていない）。
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM market.bars WHERE source='jquants' AND run_id=%s",
+            (run.run_id,),
+        )
+        assert cur.fetchone()[0] == 1
+
+
+def test_run_daily_with_statements_false_skips_statements(conn, run, store, fetcher):
+    """--no-statements 相当（with_statements=False）で財務段を丸ごとスキップする。"""
+    fetcher.add("equities/bars/daily", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","O":1,"H":2,"L":1,"C":2,"Vo":10}]}',
+    ))
+    # fins/summary へは叩かない（登録しない = FakeFetcher の 404 に落ちない）ことを確認。
+    result = jquants.run_daily(
+        conn, run, store, fetcher,
+        quote_date="2026-08-03", with_instruments=False, with_statements=False,
+        key="KEY123",
+    )
+    assert result.statements == {}
+    # fetcher.calls に fins/summary への呼び出しが無いこと。
+    assert not any("fins/summary" in c for c in fetcher.calls)
+
+
+def test_backfill_statements_processes_weekdays_only(conn, store, fetcher):
+    """バックフィル: 平日のみを日次処理し、合計サマリを返す。"""
+    # 2026-05-01(金) 〜 2026-05-08(金): 8 日中平日は 6 日（5/2 土・5/3 日を除く）。
+    # 全日に対して同一 DiscNo の 1 件を返すモック（冪等キー確認も兼ねる）。
+    fetcher.add("fins/summary", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","DiscDate":"2026-05-01",'
+             b'"DiscNo":"BF-01","DocType":"FYFinancialStatements"}]}',
+    ))
+    summary = jquants.run_backfill_statements(
+        conn, fetcher, store,
+        date_from=date(2026, 5, 1), date_to=date(2026, 5, 8),
+        key="KEY123", sleep_sec=0, progress_every=100,
+    )
+    assert summary["days"] == 6
+    # 冪等キー（DiscDate+DiscNo）が同一なので written は初回の 1 件のみ、以降は 0。
+    assert summary["total"] == 6
+    assert summary["written"] == 1
+    # 土日には API を叩いていない（呼び出し回数=6）。
+    call_count = sum(1 for c in fetcher.calls if "fins/summary" in c)
+    assert call_count == 6
+    # 呼び出しに 5/2(土)・5/3(日) の date パラメータが混入していない。
+    assert not any("date=2026-05-02" in c or "date=2026-05-03" in c
+                   for c in fetcher.calls)
+
+
+def test_backfill_statements_idempotent_on_rerun(conn, store, fetcher):
+    """バックフィル: 再実行で written=0（DiscDate+DiscNo が冪等キー）。"""
+    fetcher.add("fins/summary", FetchResult(
+        status=200,
+        body=b'{"data": [{"Code":"72030","DiscDate":"2026-05-04",'
+             b'"DiscNo":"BF-IDEM","DocType":"FYFinancialStatements"}]}',
+    ))
+    kw = dict(
+        date_from=date(2026, 5, 4), date_to=date(2026, 5, 4),
+        key="KEY123", sleep_sec=0, progress_every=100,
+    )
+    r1 = jquants.run_backfill_statements(conn, fetcher, store, **kw)
+    r2 = jquants.run_backfill_statements(conn, fetcher, store, **kw)
+    assert r1 == {"days": 1, "written": 1, "total": 1}
+    assert r2 == {"days": 1, "written": 0, "total": 1}
+
+
+def test_backfill_statements_rejects_reversed_range():
+    days = jquants._weekday_range(date(2026, 5, 5), date(2026, 5, 1))
+    assert days == []  # 開始 > 終了は空（呼び出しゼロ・レンジ検査は CLI 側）
+
+
+def test_main_effective_date_applies_to_statements(conn, store, fetcher):
+    """run_daily 呼び出し時、statements も quote_date（=実効日）で叩かれる。
+
+    daily の実効日丸め（effective_quote_date, Issue #38）が statements にも一貫して適用
+    されることを、URL の date パラメータで直接確認する（T-030 §4）。
+    """
+    fetcher.add("equities/bars/daily", FetchResult(
+        status=200, body=b'{"data": []}',
+    ))
+    fetcher.add("fins/summary", FetchResult(
+        status=200, body=b'{"data": []}',
+    ))
+    from ryza.provenance import start_run
+
+    r = start_run("test.jquants.eff", conn=conn)
+    jquants.run_daily(
+        conn, r, store, fetcher,
+        quote_date="2026-05-04", with_instruments=False, key="KEY",
+    )
+    # statements の呼び出しに date=2026-05-04 が渡っている。
+    stmt_calls = [c for c in fetcher.calls if "fins/summary" in c]
+    assert stmt_calls, "fins/summary が呼ばれていない"
+    assert all("date=2026-05-04" in c for c in stmt_calls)
 
 
 def test_normalize_symbol():


### PR DESCRIPTION
## Summary
- **背景**: `ingest_statements` / `fetch_statements` は実装・テスト済みだったが **どこからも呼ばれておらず**、`docs.documents` に source_name='J-Quants' & kind='financial_statement' の行は 0 件のまま。T-029(financial の数値昇格)と T-019(Peter=GARP)の前提が空転していた
- **配線**: `run_daily` に `fetch_statements(stmt_date=<実効日>)` → `ingest_statements` を追加。`DailyResult.statements` に `{'written','total'}` か `{'error':...}` を必ず載せる。実効日は `effective_quote_date`(Free プラン 12 週遅延)を日足と共有
- **失敗分離**: statements の HTTP エラーは日足取込を巻き添えにしない(例外を捕捉して error として記録)。`--no-statements` フラグで段丸ごとスキップ可能(反対意見書 §6.2)
- **バックフィル CLI**: `--backfill-statements-from YYYY-MM-DD` / `--backfill-statements-to YYYY-MM-DD`(両方指定で発動)。両端含む・平日のみ日次処理、冪等キー(DiscDate+DiscNo)で再実行安全、レート配慮の 1 秒 sleep、20 日ごとに進捗ログ
- **`src/ryza/jobs/daily.py` には触れていない**(`jquants.main` の内側で完結)
- **バックフィル自体はこの PR では実行しない** — マージ後に設計リードが任意範囲で実行する
- **実 API 確認**(2026-08-04): `/v2/fins/summary?date=2026-05-01` は Free プランで **HTTP 200 / 1 件以上の DiscDate 付きレスポンス**を返す(空回りしないことを確認済み)

## Test plan
- [x] `RYZA_TEST_DATABASE_URL=... pytest tests/ingest/test_jquants.py -q` → **26 passed**(既存 21 + 追加 5 相当)
- [x] `ruff check src/ryza/ingest/jquants.py tests/ingest/test_jquants.py` → All checks passed
- [ ] CI green(合否の正)
- [ ] 独立審査(この PR 自体は新規モジュール・保護領域・スキーマ変更を含まないため required ではないが、`fetch_statements` / `ingest_statements` を実行経路に載せる変更のため任意で回すのが望ましい)

## 追加したテスト(§4)
1. `test_run_daily_writes_statements_alongside_bars`: run_daily が statements を取込し `docs.documents` に書き込む
2. `test_run_daily_statements_error_does_not_break_bars`: 500 が返っても日足 written は維持され、`statements={'error':...}` として記録
3. `test_run_daily_with_statements_false_skips_statements`: フラグで完全スキップ・API を叩かない
4. `test_backfill_statements_processes_weekdays_only`: 8 日(5/1〜5/8)中平日 6 日のみを処理、冪等再実行で written=0、土日は URL に現れない
5. `test_backfill_statements_idempotent_on_rerun`: DiscDate+DiscNo 冪等
6. `test_main_effective_date_applies_to_statements`: quote_date が statements の date パラメータに一貫適用

## 反対意見書(指示書 §6 より)
1. **日次で date 指定だと開示の重複/取りこぼしの境界がある** — 反論: 冪等キーで重複無害、欠落はバックフィルで再取得可能
2. **statements は別ジョブにすべき** — 反論: 同一 API・同一遅延の 2 ジョブ運用コストが高い。`--no-statements` で分離余地を残した
3. **Free プランの範囲確認が先** — 実 API で 200 を確認済み(上記)